### PR TITLE
Remove git dependency

### DIFF
--- a/src-tauri/server-components/pyproject.toml
+++ b/src-tauri/server-components/pyproject.toml
@@ -3,7 +3,7 @@ name = "biome-server"
 version = "0.1.0"
 requires-python = "==3.13.*"
 dependencies = [
-  "world-engine @ git+https://github.com/Wayfarer-Labs/world_engine.git@websocket",
+  "world-engine @ https://github.com/Wayfarer-Labs/world_engine/archive/refs/heads/websocket.zip",
   "pillow",
   "fastapi>=0.128.0",
   "uvicorn>=0.40.0",


### PR DESCRIPTION
Fixes #16. `uv sync` successful with following:
```
Resolved 78 packages in 9.10s
      Built world-engine @ https://github.com/Wayfarer-Labs/world_engine/archive/refs/heads/websocket.zip
Prepared 1 package in 3.27s
Uninstalled 2 packages in 62ms
Installed 1 package in 13ms
 - timm==1.0.24
 - world-engine==0.0.3 (from git+https://github.com/Wayfarer-Labs/world_engine.git@ff4be4e69c66777d2b2177a67299131d72d31a24)
 + world-engine==0.0.3 (from https://github.com/Wayfarer-Labs/world_engine/archive/refs/heads/websocket.zip)
```