### PR TITLE
Handle engine mode changes

### DIFF
--- a/src/context/StreamingContext.jsx
+++ b/src/context/StreamingContext.jsx
@@ -21,7 +21,7 @@ export const StreamingProvider = ({ children }) => {
   const containerRef = useRef(null)
   const canvasRef = useRef(null)
 
-  const { config, reloadConfig, saveConfig, isStandaloneMode } = useConfig()
+  const { config, reloadConfig, saveConfig, isStandaloneMode, engineMode } = useConfig()
   const {
     status: engineStatus,
     startServer,


### PR DESCRIPTION
The current version of Biome requires a full restart to respond to a change in engine mode behaviour (e.g. server -> bundled or vice versa). This should fix that, but I haven't tested it. Need to confirm that both directions work and that it is possible to continue from either path.