### PR TITLE
Fixes and improvements to engine install modal

### DIFF
--- a/electron/ipc/engine.ts
+++ b/electron/ipc/engine.ts
@@ -8,8 +8,10 @@ import { getHiddenWindowOptions, getUvArchiveName, getVenvPythonPath } from '../
 import { getServerState } from '../lib/serverState.js'
 import { runUvSyncWithMirroredLogs } from '../lib/uvSync.js'
 import { copyServerComponentFiles } from '../lib/serverFiles.js'
+import { emitToAllWindows } from '../lib/ipcUtils.js'
 
 const UV_VERSION = '0.9.26'
+let syncDependenciesAbortController: AbortController | null = null
 
 function execFileAsync(file: string, args: string[], options?: Parameters<typeof execFile>[2]): Promise<void> {
   return new Promise((resolve, reject) => {
@@ -206,12 +208,18 @@ export function registerEngineIpc(): void {
   })
 
   ipcMain.handle('sync-engine-dependencies', async () => {
+    if (syncDependenciesAbortController) {
+      throw new Error('Engine dependency sync is already running')
+    }
+
     const engineDir = getEngineDir()
     const uvDir = getUvDir()
     const uvBinary = getUvBinaryPath()
     const uvEnv = getUvEnvVars()
+    syncDependenciesAbortController = new AbortController()
 
     if (!fs.existsSync(engineDir)) {
+      syncDependenciesAbortController = null
       throw new Error('Engine repository not found. Please clone it first.')
     }
 
@@ -221,25 +229,44 @@ export function registerEngineIpc(): void {
     }
 
     if (!fs.existsSync(uvBinary)) {
+      syncDependenciesAbortController = null
       throw new Error('uv is not installed. Please install it first.')
     }
 
-    logEngineToConsoleAndUi('[ENGINE] Running uv sync for engine dependencies...')
-    await runUvSyncWithMirroredLogs(
-      uvBinary,
-      engineDir,
-      {
-        ...process.env,
-        ...uvEnv,
-        UV_LINK_MODE: 'copy',
-        UV_NO_EDITABLE: '1',
-        UV_MANAGED_PYTHON: '1'
-      },
-      { logPrefix: '[ENGINE]' }
-    )
-    logEngineToConsoleAndUi('[ENGINE] uv sync finished for engine dependencies')
+    try {
+      logEngineToConsoleAndUi('[ENGINE] Running uv sync for engine dependencies...')
+      await runUvSyncWithMirroredLogs(
+        uvBinary,
+        engineDir,
+        {
+          ...process.env,
+          ...uvEnv,
+          UV_LINK_MODE: 'copy',
+          UV_NO_EDITABLE: '1',
+          UV_MANAGED_PYTHON: '1'
+        },
+        {
+          logPrefix: '[ENGINE]',
+          signal: syncDependenciesAbortController.signal,
+          onLine: (line, isStderr) => {
+            emitToAllWindows('engine-install-log', { line, is_stderr: isStderr })
+          }
+        }
+      )
+      logEngineToConsoleAndUi('[ENGINE] uv sync finished for engine dependencies')
+    } finally {
+      syncDependenciesAbortController = null
+    }
 
     return 'Dependencies synced successfully'
+  })
+
+  ipcMain.handle('abort-sync-engine-dependencies', () => {
+    if (!syncDependenciesAbortController) {
+      return 'No dependency sync is currently running'
+    }
+    syncDependenciesAbortController.abort()
+    return 'Dependency sync abort requested'
   })
 
   ipcMain.handle('unpack-server-files', (_event, force: boolean) => {

--- a/electron/lib/uvSync.ts
+++ b/electron/lib/uvSync.ts
@@ -6,17 +6,25 @@ export async function runUvSyncWithMirroredLogs(
   uvBinary: string,
   cwd: string,
   env: NodeJS.ProcessEnv,
-  options?: { logPrefix?: string }
+  options?: { logPrefix?: string; signal?: AbortSignal; onLine?: (line: string, isStderr: boolean) => void }
 ): Promise<void> {
   const prefix = options?.logPrefix ?? '[UV]'
+  const signal = options?.signal
+  const onLine = options?.onLine
 
   await new Promise<void>((resolve, reject) => {
+    if (signal?.aborted) {
+      reject(new Error('Engine setup canceled by user'))
+      return
+    }
+
     const child = spawn(uvBinary, ['sync', '--verbose', '--index-strategy', 'unsafe-best-match'], {
       cwd,
       env,
       stdio: ['ignore', 'pipe', 'pipe'],
       ...getHiddenWindowOptions()
     })
+    let aborted = false
 
     const tail: string[] = []
     const handleLine = (line: string, isStderr: boolean) => {
@@ -26,6 +34,7 @@ export async function runUvSyncWithMirroredLogs(
       } else {
         console.log(prefixed)
       }
+      onLine?.(prefixed, isStderr)
       tail.push(prefixed)
       if (tail.length > 80) tail.shift()
     }
@@ -39,8 +48,19 @@ export async function runUvSyncWithMirroredLogs(
       rl.on('line', (line) => handleLine(line, true))
     }
 
+    const handleAbort = () => {
+      aborted = true
+      child.kill()
+    }
+    signal?.addEventListener('abort', handleAbort, { once: true })
+
     child.on('error', (err) => reject(err))
     child.on('close', (code) => {
+      signal?.removeEventListener('abort', handleAbort)
+      if (aborted) {
+        reject(new Error('Engine setup canceled by user'))
+        return
+      }
       if (code === 0) {
         resolve()
         return

--- a/src/components/EngineInstallModal.tsx
+++ b/src/components/EngineInstallModal.tsx
@@ -1,5 +1,5 @@
-import { useCallback, useState } from 'react'
-import { invoke } from '../bridge'
+import { useCallback, useEffect, useState } from 'react'
+import { invoke, listen } from '../bridge'
 import { useStreaming } from '../context/StreamingContext'
 import ServerLogDisplay from './ServerLogDisplay'
 
@@ -8,10 +8,30 @@ type EngineInstallModalProps = {
 }
 
 const EngineInstallModal = ({ onClose }: EngineInstallModalProps) => {
-  const { engineSetupInProgress, setupProgress, engineSetupError } = useStreaming()
+  const { engineSetupInProgress, setupProgress, engineSetupError, abortEngineSetup } = useStreaming()
   const [installLogs, setInstallLogs] = useState<string[]>([])
   const [isExportingInstallDiagnostics, setIsExportingInstallDiagnostics] = useState(false)
+  const [isAbortingInstall, setIsAbortingInstall] = useState(false)
   const [installExportStatus, setInstallExportStatus] = useState<string | null>(null)
+
+  useEffect(() => {
+    setInstallLogs([])
+    const unlisten = listen('engine-install-log', (payload) => {
+      setInstallLogs((prev) => {
+        const next = [...prev, payload.line]
+        if (next.length > 360) next.shift()
+        return next
+      })
+    })
+    return unlisten
+  }, [])
+
+  useEffect(() => {
+    if (engineSetupInProgress) {
+      setInstallLogs([])
+      setInstallExportStatus(null)
+    }
+  }, [engineSetupInProgress])
 
   const buildDiagnosticsPayload = useCallback(async () => {
     const meta = await invoke('get-runtime-diagnostics-meta')
@@ -51,6 +71,22 @@ const EngineInstallModal = ({ onClose }: EngineInstallModalProps) => {
     }
   }
 
+  const handleAbortInstall = async () => {
+    if (isAbortingInstall) return
+
+    setIsAbortingInstall(true)
+    setInstallExportStatus(null)
+    try {
+      const message = await abortEngineSetup()
+      setInstallExportStatus(message || 'Abort requested')
+    } catch (abortErr) {
+      const message = abortErr instanceof Error ? abortErr.message : 'Failed to abort install'
+      setInstallExportStatus(message)
+    } finally {
+      setIsAbortingInstall(false)
+    }
+  }
+
   return (
     <div
       className="absolute inset-0 z-[12] flex items-center justify-center bg-[var(--color-overlay-scrim)] backdrop-blur-sm"
@@ -61,6 +97,7 @@ const EngineInstallModal = ({ onClose }: EngineInstallModalProps) => {
         <ServerLogDisplay
           variant="loading-inline"
           title="WORLD ENGINE INSTALL"
+          externalLogs={installLogs}
           showProgress={engineSetupInProgress}
           progressMessage={
             engineSetupInProgress
@@ -82,9 +119,20 @@ const EngineInstallModal = ({ onClose }: EngineInstallModalProps) => {
           isExportingAction={isExportingInstallDiagnostics}
           exportActionLabel="Export Logs"
           showDismiss={false}
-          onLogsChange={setInstallLogs}
           headerAction={
-            !engineSetupInProgress ? (
+            engineSetupInProgress ? (
+              <div className="flex items-center gap-[0.8cqh]">
+                <button
+                  type="button"
+                  className="loading-inline-logs-close"
+                  onClick={() => void handleAbortInstall()}
+                  disabled={isAbortingInstall}
+                  aria-label="Abort engine install"
+                >
+                  {isAbortingInstall ? 'Aborting...' : 'Abort'}
+                </button>
+              </div>
+            ) : (
               <div className="flex items-center gap-[0.8cqh]">
                 <button
                   type="button"
@@ -95,7 +143,7 @@ const EngineInstallModal = ({ onClose }: EngineInstallModalProps) => {
                   Close
                 </button>
               </div>
-            ) : null
+            )
           }
         />
         {installExportStatus && (

--- a/src/context/StreamingContext.tsx
+++ b/src/context/StreamingContext.tsx
@@ -62,6 +62,7 @@ export const StreamingProvider = ({ children }: { children: ReactNode }) => {
     probeServerHealth,
     serverLogPath,
     setupEngine,
+    abortSyncDependencies,
     setupProgress,
     isLoading: engineSetupInProgress,
     error: engineSetupError
@@ -565,6 +566,7 @@ export const StreamingProvider = ({ children }: { children: ReactNode }) => {
     engineStatus,
     checkEngineStatus,
     setupEngine,
+    abortEngineSetup: abortSyncDependencies,
     engineSetupInProgress,
     setupProgress,
     engineSetupError,

--- a/src/context/streamingContextTypes.ts
+++ b/src/context/streamingContextTypes.ts
@@ -42,6 +42,7 @@ export type StreamingContextValue = {
   engineStatus: EngineStatus | null
   checkEngineStatus: () => Promise<EngineStatus | null>
   setupEngine: (onStage?: (stageId: StageId) => void) => Promise<EngineStatus>
+  abortEngineSetup: () => Promise<string>
   engineSetupInProgress: boolean
   setupProgress: string | null
   engineSetupError: string | null

--- a/src/hooks/useEngine.ts
+++ b/src/hooks/useEngine.ts
@@ -13,6 +13,7 @@ export type UseEngineResult = {
   installUv: () => Promise<string>
   setupServerComponents: () => Promise<string>
   syncDependencies: () => Promise<string>
+  abortSyncDependencies: () => Promise<string>
   setupEngine: (onStage?: (stageId: StageId) => void) => Promise<EngineStatus>
   startServer: (port: number) => Promise<string>
   stopServer: () => Promise<string>
@@ -96,6 +97,15 @@ export const useEngine = (): UseEngineResult => {
     } finally {
       setIsLoading(false)
       setSetupProgress(null)
+    }
+  }, [])
+
+  const abortSyncDependencies = useCallback(async () => {
+    try {
+      return await invoke('abort-sync-engine-dependencies')
+    } catch (err) {
+      setError(err instanceof Error ? err.message : String(err))
+      throw err
     }
   }, [])
 
@@ -214,6 +224,7 @@ export const useEngine = (): UseEngineResult => {
     installUv,
     setupServerComponents,
     syncDependencies,
+    abortSyncDependencies,
     setupEngine,
     startServer,
     stopServer,

--- a/src/types/ipc.ts
+++ b/src/types/ipc.ts
@@ -66,6 +66,7 @@ export type IpcCommandMap = {
   'install-uv': { args: []; return: string }
   'setup-server-components': { args: []; return: string }
   'sync-engine-dependencies': { args: []; return: string }
+  'abort-sync-engine-dependencies': { args: []; return: string }
   'unpack-server-files': { args: [force: boolean]; return: string }
 
   // Server
@@ -109,5 +110,6 @@ export type IpcCommandMap = {
 export type IpcEventMap = {
   'server-ready': boolean
   'server-stage': { id: string; label: string; percent: number }
+  'engine-install-log': { line: string; is_stderr: boolean }
   'window-resized': { width: number; height: number }
 }


### PR DESCRIPTION
Fixes #54 

Also implements the following:
- [x] A cancel/abort operation button for the installation / uv sync check
- [x] Fix the child process output piping to the engine, right now it's broken 