### PR TITLE
feat: setup nsis installer .nsh

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -1,3 +1,4 @@
 server-components
 out
 .vite
+build/installer.nsh

--- a/build/installer.nsh
+++ b/build/installer.nsh
@@ -1,0 +1,41 @@
+!macro customRemoveFiles
+  StrCpy $R0 "$PLUGINSDIR\biome-seeds-backup"
+  StrCpy $R1 "$PLUGINSDIR\biome-hf-cache-backup"
+
+  ${if} ${isUpdated}
+    DetailPrint "Upgrade detected: preserving custom seeds and Hugging Face cache."
+
+    RMDir /r "$R0"
+    RMDir /r "$R1"
+
+    IfFileExists "$INSTDIR\world_engine\seeds\uploads\*" 0 +2
+      Rename "$INSTDIR\world_engine\seeds\uploads" "$R0"
+    IfFileExists "$INSTDIR\world_engine\.cache\huggingface\hub\*" 0 +2
+      Rename "$INSTDIR\world_engine\.cache\huggingface\hub" "$R1"
+
+    # Keep standard upgrade behavior: remove previous install before reinstalling.
+    RMDir /r "$INSTDIR"
+
+    IfFileExists "$R0\*" 0 +3
+      CreateDirectory "$INSTDIR\world_engine\seeds"
+      Rename "$R0" "$INSTDIR\world_engine\seeds\uploads"
+
+    IfFileExists "$R1\*" 0 +4
+      CreateDirectory "$INSTDIR\world_engine\.cache"
+      CreateDirectory "$INSTDIR\world_engine\.cache\huggingface"
+      Rename "$R1" "$INSTDIR\world_engine\.cache\huggingface\hub"
+  ${else}
+    # Keep user-imported custom seeds across a full uninstall.
+    RMDir /r "$R0"
+    IfFileExists "$INSTDIR\world_engine\seeds\uploads\*" 0 +2
+      Rename "$INSTDIR\world_engine\seeds\uploads" "$R0"
+
+    # Remove installed files, including model/cache directories.
+    RMDir /r "$INSTDIR"
+
+    # Restore custom seeds if they were backed up.
+    IfFileExists "$R0\*" 0 +3
+      CreateDirectory "$INSTDIR\world_engine\seeds"
+      Rename "$R0" "$INSTDIR\world_engine\seeds\uploads"
+  ${endif}
+!macroend

--- a/forge.config.ts
+++ b/forge.config.ts
@@ -27,6 +27,7 @@ const config: ForgeConfig = {
           oneClick: false,
           allowToChangeInstallationDirectory: true,
           license: 'licensing/EULA.txt',
+          include: 'build/installer.nsh',
           installerIcon: 'app-icon.ico',
           uninstallerIcon: 'app-icon.ico'
         }


### PR DESCRIPTION
Fixes #58.

On upgrade:
- backs up world_engine\seeds\uploads + world_engine\.cache\huggingface\hub
- Performs normal cleanup: RMDir /r "$INSTDIR"
- Restores both backup folders into the new install directory.

Full uninstall:
- Backs up only world_engine\seeds\uploads
- Removes $INSTDIR (so models/HF cache are deleted)
- Keeps custom user seeds