### PR TITLE
Add model info (size, availability) + connect to server in settings

### DIFF
--- a/electron/ipc/models.ts
+++ b/electron/ipc/models.ts
@@ -1,7 +1,9 @@
 import { ipcMain } from 'electron'
 import fs from 'node:fs'
+import os from 'node:os'
 import path from 'node:path'
 import { getHfHubCacheDir } from '../lib/paths.js'
+import type { ModelInfo } from '../../src/types/ipc.js'
 
 const DEFAULT_WORLD_ENGINE_MODEL = 'Overworld/Waypoint-1-Small'
 const WAYPOINT_COLLECTION_API_URL = 'https://huggingface.co/api/collections/Overworld/waypoint-1'
@@ -51,6 +53,113 @@ async function listWaypointModels(): Promise<string[]> {
   return models
 }
 
+function readFileIfExists(filePath: string): string | null {
+  try {
+    const content = fs.readFileSync(filePath, 'utf-8').trim()
+    return content || null
+  } catch {
+    return null
+  }
+}
+
+function getHfToken(): string | null {
+  // 1. HF_TOKEN env var
+  if (process.env.HF_TOKEN) return process.env.HF_TOKEN
+  // 2. Deprecated HUGGING_FACE_HUB_TOKEN env var
+  if (process.env.HUGGING_FACE_HUB_TOKEN) return process.env.HUGGING_FACE_HUB_TOKEN
+  // 3. File at HF_TOKEN_PATH env var
+  if (process.env.HF_TOKEN_PATH) {
+    const token = readFileIfExists(process.env.HF_TOKEN_PATH)
+    if (token) return token
+  }
+  // 4. File at $HF_HOME/token
+  if (process.env.HF_HOME) {
+    const token = readFileIfExists(path.join(process.env.HF_HOME, 'token'))
+    if (token) return token
+  }
+  // 5. File at $XDG_CACHE_HOME/huggingface/token
+  if (process.env.XDG_CACHE_HOME) {
+    const token = readFileIfExists(path.join(process.env.XDG_CACHE_HOME, 'huggingface', 'token'))
+    if (token) return token
+  }
+  // 6. File at ~/.cache/huggingface/token
+  const token = readFileIfExists(path.join(os.homedir(), '.cache', 'huggingface', 'token'))
+  if (token) return token
+
+  return null
+}
+
+type HfApiSibling = { rfilename: string; size?: number; blobId?: string }
+type HfApiResponse = {
+  siblings?: HfApiSibling[]
+}
+
+function extractSizeBytes(info: HfApiResponse): number | null {
+  if (!info.siblings) return null
+  const safetensorFiles = info.siblings.filter((s) => s.rfilename.endsWith('.safetensors') && s.size != null)
+  if (safetensorFiles.length === 0) return null
+  // Deduplicate by blobId to avoid counting symlinked files twice
+  const seen = new Set<string>()
+  let total = 0
+  for (const s of safetensorFiles) {
+    const key = s.blobId ?? s.rfilename
+    if (!seen.has(key)) {
+      seen.add(key)
+      total += s.size ?? 0
+    }
+  }
+  return total
+}
+
+async function getModelInfoFromHf(modelId: string): Promise<ModelInfo> {
+  try {
+    const token = getHfToken()
+    const headers: Record<string, string> = {}
+    if (token) headers['Authorization'] = `Bearer ${token}`
+
+    const response = await fetch(`https://huggingface.co/api/models/${modelId}?blobs=true`, {
+      headers
+    })
+
+    if (response.status === 404) {
+      return { id: modelId, size_bytes: null, exists: false, error: 'Model not found' }
+    }
+    if (response.status === 401 || response.status === 403) {
+      return { id: modelId, size_bytes: null, exists: true, error: 'Private or gated model' }
+    }
+    if (!response.ok) {
+      return { id: modelId, size_bytes: null, exists: true, error: 'Could not check model' }
+    }
+
+    const info = (await response.json()) as HfApiResponse
+    return {
+      id: modelId,
+      size_bytes: extractSizeBytes(info),
+      exists: true,
+      error: null
+    }
+  } catch {
+    return { id: modelId, size_bytes: null, exists: true, error: 'Could not check model' }
+  }
+}
+
+async function getModelInfoFromServer(serverUrl: string, modelId: string): Promise<ModelInfo> {
+  try {
+    const controller = new AbortController()
+    const timeout = setTimeout(() => controller.abort(), 10000)
+    const response = await fetch(`${serverUrl}/api/model-info/${modelId}`, {
+      signal: controller.signal
+    })
+    clearTimeout(timeout)
+    if (!response.ok) {
+      return { id: modelId, size_bytes: null, exists: true, error: `Server returned ${response.status}` }
+    }
+    return (await response.json()) as ModelInfo
+  } catch {
+    return { id: modelId, size_bytes: null, exists: true, error: 'Could not reach server' }
+  }
+}
+
 export function registerModelsIpc(): void {
   ipcMain.handle('list-waypoint-models', async () => {
     return listWaypointModels()
@@ -74,5 +183,22 @@ export function registerModelsIpc(): void {
       id,
       is_local: isModelCachedInHfHub(id, hubDir)
     }))
+  })
+
+  ipcMain.handle('get-models-info', async (_event, modelIds: string[], serverUrl?: string) => {
+    const seen = new Set<string>()
+    const deduped = modelIds.map((id) => id.trim()).filter((id) => id.length > 0 && !seen.has(id) && seen.add(id))
+
+    if (deduped.length === 0) return []
+
+    const results = await Promise.allSettled(
+      deduped.map((id) => (serverUrl ? getModelInfoFromServer(serverUrl, id) : getModelInfoFromHf(id)))
+    )
+
+    return results.map((result, i) =>
+      result.status === 'fulfilled'
+        ? result.value
+        : { id: deduped[i], size_bytes: null, exists: true, error: 'Fetch failed' }
+    )
   })
 }

--- a/server-components/server.py
+++ b/server-components/server.py
@@ -35,19 +35,62 @@ from pathlib import Path
 from queue import Empty, Queue
 from typing import Optional
 
+from huggingface_hub import model_info as hf_model_info
+from huggingface_hub.utils import GatedRepoError, RepositoryNotFoundError
+
 # Resolve HuggingFace token: env var > CLI-cached token file.
 # Biome overrides HF_HOME to keep model cache inside world_engine/, which means
 # the huggingface_hub library won't find the user's default token at
-# ~/.cache/huggingface/token. Read it manually as a fallback.
-if not os.environ.get("HF_TOKEN") and not os.environ.get("HUGGING_FACE_HUB_TOKEN"):
-    _hf_token_path = Path.home() / ".cache" / "huggingface" / "token"
-    if _hf_token_path.is_file():
-        _token = _hf_token_path.read_text().strip()
-        if _token:
-            os.environ["HF_TOKEN"] = _token
-            print(f"[BIOME] HF token loaded from {_hf_token_path}", flush=True)
-    else:
-        print("[BIOME] Warning: No HuggingFace token found (set HF_TOKEN or run `huggingface-cli login`)", flush=True)
+# ~/.cache/huggingface/token. We check multiple locations to match the Electron
+# side's resolution order.
+
+
+def resolve_hf_token() -> Optional[str]:
+    """Resolve HuggingFace token from env vars and well-known file locations.
+
+    Mirrors the Electron-side getHfToken() resolution order so both paths
+    find the same token regardless of HF_HOME overrides.
+    """
+    # 1. HF_TOKEN env var
+    token = os.environ.get("HF_TOKEN")
+    if token:
+        return token
+    # 2. Deprecated HUGGING_FACE_HUB_TOKEN env var
+    token = os.environ.get("HUGGING_FACE_HUB_TOKEN")
+    if token:
+        return token
+    # 3. File at HF_TOKEN_PATH env var
+    token_path_env = os.environ.get("HF_TOKEN_PATH")
+    if token_path_env:
+        p = Path(token_path_env)
+        if p.is_file():
+            t = p.read_text().strip()
+            if t:
+                return t
+    # 4. File at real user HF_HOME/token (use XDG_CACHE_HOME or ~/.cache,
+    #    NOT the overridden HF_HOME which points into world_engine/)
+    xdg = os.environ.get("XDG_CACHE_HOME")
+    if xdg:
+        p = Path(xdg) / "huggingface" / "token"
+        if p.is_file():
+            t = p.read_text().strip()
+            if t:
+                return t
+    # 5. Default fallback: ~/.cache/huggingface/token
+    p = Path.home() / ".cache" / "huggingface" / "token"
+    if p.is_file():
+        t = p.read_text().strip()
+        if t:
+            return t
+    return None
+
+
+_resolved_token = resolve_hf_token()
+if _resolved_token:
+    os.environ["HF_TOKEN"] = _resolved_token
+    print(f"[BIOME] HF token resolved and set", flush=True)
+else:
+    print("[BIOME] Warning: No HuggingFace token found (set HF_TOKEN or run `huggingface-cli login`)", flush=True)
 
 # Reduce CUDA allocator fragmentation during repeated model loads/switches.
 os.environ.setdefault("PYTORCH_CUDA_ALLOC_CONF", "expandable_segments:True")
@@ -716,7 +759,7 @@ def compute_file_hash(file_path: str) -> str:
 
 
 # ============================================================================
-# Health Endpoint (only REST endpoint kept)
+# HTTP Endpoints
 # ============================================================================
 
 
@@ -735,6 +778,31 @@ async def health():
             "safety": {"loaded": safety_checker is not None and safety_checker.model is not None},
         }
     )
+
+
+@app.get("/api/model-info/{model_id:path}")
+async def get_model_info(model_id: str):
+    """Fetch model metadata from HuggingFace Hub."""
+    try:
+        info = hf_model_info(model_id, files_metadata=True)
+        size_bytes = None
+        if hasattr(info, "siblings") and info.siblings:
+            st_files = [s for s in info.siblings if s.rfilename.endswith(".safetensors") and s.size is not None]
+            # Deduplicate by blob hash to avoid counting symlinked files twice
+            seen_blobs = set()
+            for s in st_files:
+                blob_key = getattr(s, "blob_id", None) or s.rfilename
+                if blob_key not in seen_blobs:
+                    seen_blobs.add(blob_key)
+                    size_bytes = (size_bytes or 0) + s.size
+        return JSONResponse({"id": model_id, "size_bytes": size_bytes, "exists": True, "error": None})
+    except RepositoryNotFoundError:
+        return JSONResponse({"id": model_id, "size_bytes": None, "exists": False, "error": "Model not found"})
+    except GatedRepoError:
+        return JSONResponse({"id": model_id, "size_bytes": None, "exists": True, "error": "Private or gated model"})
+    except Exception as e:
+        logger.warning(f"model-info error for {model_id}: {e}")
+        return JSONResponse({"id": model_id, "size_bytes": None, "exists": True, "error": "Could not check model"})
 
 
 # ============================================================================
@@ -799,6 +867,8 @@ async def dispatch_request(msg: dict, websocket: WebSocket) -> dict | BinaryResp
         return await _handle_seeds_delete(msg)
     elif req_type == "seeds_rescan":
         return await _handle_seeds_rescan(msg)
+    elif req_type == "model_info":
+        return await _handle_model_info(msg)
     else:
         return {"success": False, "error": f"Unknown request type: {req_type}"}
 
@@ -1089,6 +1159,34 @@ async def _handle_seeds_rescan(msg: dict) -> dict:
                 "safe_seeds": safe_count,
             },
         }
+
+
+async def _handle_model_info(msg: dict) -> dict:
+    """Fetch model info from HuggingFace Hub via WS RPC."""
+    model_id = msg.get("model_id", "")
+    if not model_id:
+        return {"success": False, "error": "model_id is required"}
+
+    try:
+        info = hf_model_info(model_id, files_metadata=True)
+        size_bytes = None
+        if hasattr(info, "siblings") and info.siblings:
+            st_files = [s for s in info.siblings if s.rfilename.endswith(".safetensors") and s.size is not None]
+            # Deduplicate by blob hash to avoid counting symlinked files twice
+            seen_blobs = set()
+            for s in st_files:
+                blob_key = getattr(s, "blob_id", None) or s.rfilename
+                if blob_key not in seen_blobs:
+                    seen_blobs.add(blob_key)
+                    size_bytes = (size_bytes or 0) + s.size
+        return {"success": True, "data": {"id": model_id, "size_bytes": size_bytes, "exists": True, "error": None}}
+    except RepositoryNotFoundError:
+        return {"success": True, "data": {"id": model_id, "size_bytes": None, "exists": False, "error": "Model not found"}}
+    except GatedRepoError:
+        return {"success": True, "data": {"id": model_id, "size_bytes": None, "exists": True, "error": "Private or gated model"}}
+    except Exception as e:
+        logger.warning(f"model_info WS error for {model_id}: {e}")
+        return {"success": True, "data": {"id": model_id, "size_bytes": None, "exists": True, "error": "Could not check model"}}
 
 
 # ============================================================================

--- a/src/components/MenuSettingsView.tsx
+++ b/src/components/MenuSettingsView.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect, useCallback } from 'react'
+import { useState, useEffect, useCallback, useRef } from 'react'
 import { invoke } from '../bridge'
 import { HEADING_BASE, SETTINGS_LABEL_BASE, SETTINGS_MUTED_TEXT } from '../styles'
 import { useSettings } from '../hooks/useSettings'
@@ -23,7 +23,13 @@ import attributionText from '../../assets/audio/ATTRIBUTION.md?raw'
 
 type MenuModelOption = {
   id: string
-  isLocal: boolean
+  isLocal: boolean | null
+  sizeBytes: number | null
+}
+
+function formatBytes(bytes: number): string {
+  if (bytes < 1024 * 1024 * 1024) return `${(bytes / (1024 * 1024)).toFixed(0)} MB`
+  return `${(bytes / (1024 * 1024 * 1024)).toFixed(1)} GB`
 }
 
 type KeybindRowProps =
@@ -84,7 +90,7 @@ const MenuSettingsView = ({ onBack }: MenuSettingsViewProps) => {
     streamingToMenu(settings.mouse_sensitivity ?? mouseSensitivity)
   )
   const [menuModelOptions, setMenuModelOptions] = useState<MenuModelOption[]>([
-    { id: configWorldModel, isLocal: false }
+    { id: configWorldModel, isLocal: false, sizeBytes: null }
   ])
   const [menuModelsLoading, setMenuModelsLoading] = useState(false)
   const [menuModelsError, setMenuModelsError] = useState<string | null>(null)
@@ -101,6 +107,15 @@ const MenuSettingsView = ({ onBack }: MenuSettingsViewProps) => {
   const configServerUrl = settings.server_url
   const [menuServerUrl, setMenuServerUrl] = useState(configServerUrl)
 
+  const [serverUrlStatus, setServerUrlStatus] = useState<'idle' | 'loading' | 'valid' | 'error'>('idle')
+  const [lastValidatedServerUrl, setLastValidatedServerUrl] = useState('')
+  const [showServerErrorModal, setShowServerErrorModal] = useState(false)
+
+  const [customModelStatus, setCustomModelStatus] = useState<{
+    state: 'idle' | 'loading' | 'error'
+    error: string | null
+  }>({ state: 'idle', error: null })
+
   const engineReady = engineStatus
     ? engineStatus.uv_installed && engineStatus.repo_cloned && engineStatus.dependencies_synced
     : null
@@ -112,8 +127,47 @@ const MenuSettingsView = ({ onBack }: MenuSettingsViewProps) => {
     }
   }, [menuEngineMode, checkEngineStatus])
 
-  // Load model list
+  // Auto-validate server URL when entering server mode or opening settings with a saved URL.
+  // Uses a ref to avoid including serverUrlStatus in deps (which would cancel the in-flight probe).
+  const serverUrlStatusRef = useRef(serverUrlStatus)
+  serverUrlStatusRef.current = serverUrlStatus
   useEffect(() => {
+    if (menuEngineMode !== 'server') return
+    if (!menuServerUrl.trim()) return
+    if (serverUrlStatusRef.current !== 'idle') return
+
+    let cancelled = false
+    const validate = async () => {
+      setServerUrlStatus('loading')
+      try {
+        const ok = await invoke('probe-server-health', `${menuServerUrl}/health`, 5000)
+        if (cancelled) return
+        if (ok) {
+          setServerUrlStatus('valid')
+          setLastValidatedServerUrl(menuServerUrl)
+        } else {
+          setServerUrlStatus('error')
+        }
+      } catch {
+        if (!cancelled) setServerUrlStatus('error')
+      }
+    }
+    validate()
+    return () => {
+      cancelled = true
+    }
+  }, [menuEngineMode, menuServerUrl])
+
+  // Load model list — refetch when mode, server URL, or selected model changes
+  const serverUrlForModels = menuEngineMode === 'server' ? menuServerUrl : undefined
+  useEffect(() => {
+    // In server mode, don't fetch until server is validated
+    if (menuEngineMode === 'server' && serverUrlStatus !== 'valid') {
+      setMenuModelOptions([{ id: menuWorldModel, isLocal: false, sizeBytes: null }])
+      setMenuModelsLoading(false)
+      return
+    }
+
     let cancelled = false
 
     const loadMenuModels = async () => {
@@ -127,11 +181,21 @@ const MenuSettingsView = ({ onBack }: MenuSettingsViewProps) => {
           .map((id) => id.trim())
           .filter((id) => id.length > 0)
 
-        const availability = await invoke('list-model-availability', ids)
+        const [availability, modelsInfo] = await Promise.all([
+          invoke('list-model-availability', ids),
+          invoke('get-models-info', ids, serverUrlForModels)
+        ])
         if (cancelled) return
 
         const availabilityMap = new Map((availability || []).map((entry) => [entry.id, !!entry.is_local]))
-        setMenuModelOptions(ids.map((id) => ({ id, isLocal: availabilityMap.get(id) ?? false })))
+        const infoMap = new Map((modelsInfo || []).map((entry) => [entry.id, entry]))
+        setMenuModelOptions(
+          ids.map((id) => ({
+            id,
+            isLocal: availabilityMap.get(id) ?? false,
+            sizeBytes: infoMap.get(id)?.size_bytes ?? null
+          }))
+        )
       } catch {
         if (cancelled) return
         setMenuModelsError('Could not load model list')
@@ -147,7 +211,7 @@ const MenuSettingsView = ({ onBack }: MenuSettingsViewProps) => {
     return () => {
       cancelled = true
     }
-  }, [menuWorldModel])
+  }, [menuWorldModel, menuEngineMode, serverUrlForModels, serverUrlStatus])
 
   useEffect(() => {
     setMenuEngineMode(configEngineMode === ENGINE_MODES.SERVER ? 'server' : 'standalone')
@@ -168,25 +232,73 @@ const MenuSettingsView = ({ onBack }: MenuSettingsViewProps) => {
     settings.debug_overlays.input
   ])
 
-  const handleServerUrlBlur = useCallback(() => {
+  const handleServerUrlBlur = useCallback(async () => {
+    if (!menuServerUrl.trim()) {
+      setServerUrlStatus('idle')
+      return
+    }
+
+    let normalizedUrl: string
     try {
       const url = new URL(menuServerUrl)
       const normalizedPort = Number(url.port) || (url.protocol === 'https:' ? 443 : 80)
-      const normalizedUrl = `${url.protocol}//${url.hostname}:${normalizedPort}`
+      normalizedUrl = `${url.protocol}//${url.hostname}:${normalizedPort}`
       setMenuServerUrl(normalizedUrl)
     } catch {
-      // Invalid URL — revert to config value
       setMenuServerUrl(configServerUrl)
+      return
     }
-  }, [menuServerUrl, configServerUrl])
+
+    if (normalizedUrl === lastValidatedServerUrl && serverUrlStatus === 'valid') return
+
+    setServerUrlStatus('loading')
+    try {
+      const ok = await invoke('probe-server-health', `${normalizedUrl}/health`, 5000)
+      if (ok) {
+        setServerUrlStatus('valid')
+        setLastValidatedServerUrl(normalizedUrl)
+      } else {
+        setServerUrlStatus('error')
+        setShowServerErrorModal(true)
+      }
+    } catch {
+      setServerUrlStatus('error')
+      setShowServerErrorModal(true)
+    }
+  }, [menuServerUrl, configServerUrl, lastValidatedServerUrl, serverUrlStatus])
 
   const handleEngineModeChange = (mode: 'server' | 'standalone') => {
     setMenuEngineMode(mode)
+    setServerUrlStatus('idle')
+    setLastValidatedServerUrl('')
   }
 
   const handleWorldModelChange = (model: string) => {
     setMenuWorldModel(model.trim())
+    setCustomModelStatus({ state: 'idle', error: null })
   }
+
+  const handleCustomModelBlur = useCallback(
+    async (modelId: string) => {
+      if (menuModelOptions.some((m) => m.id === modelId)) return
+      setCustomModelStatus({ state: 'loading', error: null })
+      try {
+        const results = await invoke('get-models-info', [modelId], serverUrlForModels)
+        const info = results?.[0]
+        if (info && !info.exists) {
+          setCustomModelStatus({ state: 'error', error: info.error ?? 'Model not found' })
+        } else if (info?.error) {
+          setCustomModelStatus({ state: 'error', error: info.error })
+        } else {
+          setCustomModelStatus({ state: 'idle', error: null })
+          setMenuModelOptions((prev) => [...prev, { id: modelId, isLocal: null, sizeBytes: info?.size_bytes ?? null }])
+        }
+      } catch {
+        setCustomModelStatus({ state: 'error', error: 'Could not check model' })
+      }
+    },
+    [menuModelOptions, serverUrlForModels]
+  )
 
   const handleMouseSensitivityChange = (value: number) => {
     setMenuMouseSensitivity(value)
@@ -194,12 +306,13 @@ const MenuSettingsView = ({ onBack }: MenuSettingsViewProps) => {
 
   const applyDraftSettings = useCallback(async () => {
     let nextServerUrl = menuServerUrl
-    try {
-      // Validate the URL
-      new URL(nextServerUrl)
-    } catch {
-      nextServerUrl = configServerUrl
-      setMenuServerUrl(configServerUrl)
+    if (nextServerUrl.trim()) {
+      try {
+        new URL(nextServerUrl)
+      } catch {
+        nextServerUrl = configServerUrl
+        setMenuServerUrl(configServerUrl)
+      }
     }
 
     const engineModeValue = menuEngineMode === 'server' ? ENGINE_MODES.SERVER : ENGINE_MODES.STANDALONE
@@ -235,13 +348,26 @@ const MenuSettingsView = ({ onBack }: MenuSettingsViewProps) => {
   const hasWorldModelChanged = menuWorldModel !== configWorldModel
 
   const handleBackClick = useCallback(async () => {
+    if (menuEngineMode === 'server' && (!menuServerUrl.trim() || serverUrlStatus !== 'valid')) {
+      setShowServerErrorModal(true)
+      return
+    }
     if (isStreaming && (hasEngineModeChanged || hasWorldModelChanged)) {
       setShowModeSwitchModal(true)
       return
     }
     await applyDraftSettings()
     onBack()
-  }, [isStreaming, hasEngineModeChanged, hasWorldModelChanged, applyDraftSettings, onBack])
+  }, [
+    menuEngineMode,
+    menuServerUrl,
+    serverUrlStatus,
+    isStreaming,
+    hasEngineModeChanged,
+    hasWorldModelChanged,
+    applyDraftSettings,
+    onBack
+  ])
 
   useEffect(() => {
     const handleKeyUp = (e: KeyboardEvent) => {
@@ -254,6 +380,11 @@ const MenuSettingsView = ({ onBack }: MenuSettingsViewProps) => {
   }, [handleBackClick])
 
   const handleConfirmEngineModeSwitch = async () => {
+    if (menuEngineMode === 'server' && (!menuServerUrl.trim() || serverUrlStatus !== 'valid')) {
+      setShowModeSwitchModal(false)
+      setShowServerErrorModal(true)
+      return
+    }
     setShowModeSwitchModal(false)
     await applyDraftSettings()
     onBack()
@@ -308,11 +439,31 @@ const MenuSettingsView = ({ onBack }: MenuSettingsViewProps) => {
           </SettingsSection>
 
           {menuEngineMode === 'server' && (
-            <SettingsSection title="Server URL" description="the address of the GPU server running the model">
+            <SettingsSection
+              title="Server URL"
+              description={
+                <span className="inline-flex items-center gap-[0.71cqh]">
+                  the address of the GPU server running the model
+                  {serverUrlStatus === 'loading' && ' · checking...'}
+                  {serverUrlStatus === 'valid' && (
+                    <>
+                      {' · connected'}
+                      <span className="inline-block w-[0.98cqh] h-[0.98cqh] rounded-full bg-[rgba(100,220,100,0.95)] shadow-[0_0_5px_1px_rgba(100,220,100,0.4)]" />
+                    </>
+                  )}
+                  {serverUrlStatus === 'error' && (
+                    <>
+                      {' · unreachable'}
+                      <span className="inline-block w-[0.98cqh] h-[0.98cqh] rounded-full bg-[rgba(255,120,80,0.95)] shadow-[0_0_5px_1px_rgba(255,120,80,0.4)]" />
+                    </>
+                  )}
+                </span>
+              }
+            >
               <SettingsTextInput
                 value={menuServerUrl}
                 onChange={setMenuServerUrl}
-                onBlur={handleServerUrlBlur}
+                onBlur={() => void handleServerUrlBlur()}
                 placeholder="http://localhost:8000"
               />
             </SettingsSection>
@@ -331,12 +482,25 @@ const MenuSettingsView = ({ onBack }: MenuSettingsViewProps) => {
               options={menuModelOptions.map((model) => ({
                 value: model.id,
                 label: model.id.replace(/^Overworld\//, ''),
-                prefix: model.isLocal ? 'local' : 'download'
+                prefix: [
+                  model.sizeBytes != null ? formatBytes(model.sizeBytes) : null,
+                  model.isLocal === true ? 'local' : model.isLocal === false ? 'download' : null
+                ]
+                  .filter(Boolean)
+                  .join(' \u00B7 ')
               }))}
               value={menuWorldModel}
               onChange={handleWorldModelChange}
-              disabled={menuModelsLoading}
+              disabled={menuModelsLoading || (menuEngineMode === 'server' && serverUrlStatus !== 'valid')}
               allowCustom
+              onCustomBlur={handleCustomModelBlur}
+              customPrefix={
+                customModelStatus.state === 'loading'
+                  ? 'checking...'
+                  : customModelStatus.state === 'error'
+                    ? (customModelStatus.error ?? 'Model not found')
+                    : undefined
+              }
             />
             {menuModelsError && (
               <p className={`${SETTINGS_MUTED_TEXT} text-left [margin:0.35cqh_0_0.8cqh]`}>{menuModelsError}</p>
@@ -459,6 +623,25 @@ const MenuSettingsView = ({ onBack }: MenuSettingsViewProps) => {
           }}
           confirmLabel="Switch Mode"
           cancelLabel="Keep Current"
+        />
+      )}
+
+      {showServerErrorModal && (
+        <ConfirmModal
+          title="Server Unreachable"
+          description={
+            menuServerUrl.trim()
+              ? `Could not connect to ${menuServerUrl}. The server may be down, the URL may be wrong, or a firewall may be blocking the connection.`
+              : 'Please enter a server URL before leaving settings.'
+          }
+          onConfirm={() => setShowServerErrorModal(false)}
+          onCancel={() => {
+            setShowServerErrorModal(false)
+            setMenuServerUrl(configServerUrl)
+            setServerUrlStatus('idle')
+          }}
+          confirmLabel="Edit URL"
+          cancelLabel="Revert"
         />
       )}
 

--- a/src/components/ui/SettingsSelect.tsx
+++ b/src/components/ui/SettingsSelect.tsx
@@ -15,6 +15,8 @@ type SettingsSelectProps = {
   onChange: (value: string) => void
   disabled?: boolean
   allowCustom?: boolean
+  onCustomBlur?: (value: string) => void
+  customPrefix?: string
 }
 
 const OptionContent = ({ option }: { option: SettingsSelectOption }) => (
@@ -24,7 +26,15 @@ const OptionContent = ({ option }: { option: SettingsSelectOption }) => (
   </span>
 )
 
-const SettingsSelect = ({ options, value, onChange, disabled, allowCustom }: SettingsSelectProps) => {
+const SettingsSelect = ({
+  options,
+  value,
+  onChange,
+  disabled,
+  allowCustom,
+  onCustomBlur,
+  customPrefix
+}: SettingsSelectProps) => {
   const { playHover, playClick } = useUISound()
   const [isOpen, setIsOpen] = useState(false)
   const [isCustom, setIsCustom] = useState(() => allowCustom && !options.some((o) => o.value === value))
@@ -36,10 +46,22 @@ const SettingsSelect = ({ options, value, onChange, disabled, allowCustom }: Set
 
   const selectedOption = options.find((o) => o.value === value)
 
-  // Sync isCustom when options or value change — only promote to custom,
-  // never demote, so that clicking "Custom..." isn't immediately undone.
+  // Track option values to detect when the options list actually changes
+  // content (not just reference identity, which changes every render due to .map()).
+  // Demote from custom back to dropdown when a new option appears matching the
+  // current value (e.g. after validation adds it). Promote to custom when value
+  // changes to something not in options.
+  const prevOptionValuesRef = useRef(new Set(options.map((o) => o.value)))
   useEffect(() => {
-    if (allowCustom && !options.some((o) => o.value === value)) {
+    if (!allowCustom) return
+    const currentValues = new Set(options.map((o) => o.value))
+    const prevValues = prevOptionValuesRef.current
+    const inOptions = currentValues.has(value)
+    const isNewOption = inOptions && !prevValues.has(value)
+    prevOptionValuesRef.current = currentValues
+    if (isNewOption) {
+      setIsCustom(false)
+    } else if (!inOptions) {
       setIsCustom(true)
     }
   }, [allowCustom, options, value])
@@ -148,7 +170,11 @@ const SettingsSelect = ({ options, value, onChange, disabled, allowCustom }: Set
               const pasted = e.clipboardData.getData('text').trim()
               setCustomValue(pasted)
             }}
-            onBlur={commitCustomValue}
+            onBlur={() => {
+              commitCustomValue()
+              const trimmed = customValue.trim()
+              if (trimmed) onCustomBlur?.(trimmed)
+            }}
             onKeyDown={(e) => {
               if (e.key === 'Enter') {
                 e.currentTarget.blur()
@@ -156,6 +182,11 @@ const SettingsSelect = ({ options, value, onChange, disabled, allowCustom }: Set
             }}
             autoFocus
           />
+          {customPrefix && (
+            <span className="flex items-center pr-[1cqh] text-[rgba(238,244,252,0.45)] lowercase text-[2.67cqh] font-serif whitespace-nowrap">
+              {customPrefix}
+            </span>
+          )}
           <button
             type="button"
             className="flex items-center justify-center w-[3.56cqh] bg-surface-btn-primary cursor-pointer border-none"
@@ -180,11 +211,12 @@ const SettingsSelect = ({ options, value, onChange, disabled, allowCustom }: Set
     <div ref={containerRef} className="relative">
       <button
         type="button"
-        className={`w-full flex items-stretch cursor-pointer rounded-none ${SETTINGS_CONTROL_BASE} p-0 ${SETTINGS_OUTLINE_HOVER}`}
-        onMouseEnter={playHover}
+        className={`w-full flex items-stretch rounded-none ${SETTINGS_CONTROL_BASE} p-0 ${disabled ? 'opacity-40 cursor-not-allowed' : `cursor-pointer ${SETTINGS_OUTLINE_HOVER}`}`}
+        onMouseEnter={disabled ? undefined : playHover}
         onClick={() => {
+          if (disabled) return
           playClick()
-          if (!disabled) isOpen ? setIsOpen(false) : openDropdown()
+          isOpen ? setIsOpen(false) : openDropdown()
         }}
         disabled={disabled}
       >

--- a/src/types/ipc.ts
+++ b/src/types/ipc.ts
@@ -7,6 +7,13 @@ export type ModelAvailability = {
   is_local: boolean
 }
 
+export type ModelInfo = {
+  id: string
+  size_bytes: number | null
+  exists: boolean
+  error: string | null
+}
+
 export type RuntimeDiagnosticsMeta = {
   app_name: string
   app_version: string
@@ -60,6 +67,7 @@ export type IpcCommandMap = {
   // Models
   'list-waypoint-models': { args: []; return: string[] }
   'list-model-availability': { args: [modelIds: string[]]; return: ModelAvailability[] }
+  'get-models-info': { args: [modelIds: string[], serverUrl?: string]; return: ModelInfo[] }
 
   // Engine
   'check-engine-status': { args: [source?: string]; return: EngineStatus }

--- a/src/types/settings.ts
+++ b/src/types/settings.ts
@@ -32,7 +32,7 @@ export const DEFAULT_AUDIO = {
 } as const
 
 export const settingsSchema = z.object({
-  server_url: z.string().default(DEFAULT_STANDALONE_URL),
+  server_url: z.string().default(''),
   engine_mode: z.enum(['standalone', 'server']).default('standalone'),
   engine_model: z.string().default(DEFAULT_WORLD_ENGINE_MODEL),
   mouse_sensitivity: z.number().min(0.1).max(3.0).default(1.0),


### PR DESCRIPTION
- Add model size display in the World Model dropdown (e.g. "12.7 GB · local"), fetched from HuggingFace API with blob deduplication to avoid double-counting symlinked safetensors files
- Validate custom model IDs on defocus — shows "checking..." inline, then either adds the model to the dropdown with its size or shows an error
- Validate server URL on defocus and automatically on entering settings / switching to server mode, with a green/red dot status indicator in the section subtitle (matching the World  Engine style)
- Grey out the model picker in server mode until the server is confirmed reachable
- Block leaving settings with an empty or invalid server URL, showing a modal explaining possible causes
- Default server URL is now empty instead of http://localhost:7987, forcing users to enter one
- Two paths for model info: standalone mode calls the HuggingFace API directly from the Electron main process; server mode proxies through a new /api/model-info/{model_id} HTTP endpoint on the Python server
- Both Electron and Python sides resolve HuggingFace tokens using the same multi-location chain (env vars, token files, XDG paths) to handle Biome's HF_HOME override