### PR TITLE
Full-fat, all* dependencies included AppImage

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,11 +12,10 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - name: Setup Node.js
-        uses: actions/setup-node@v4
-        with:
-          node-version: '20'
-          cache: 'npm'
+      # Reuse the shared build-env script for Node — keeps the Node
+      # version in sync with the Docker image and release workflow.
+      - name: Set up build environment
+        run: sudo ./build/appimage/setup-build-env.sh
 
       - name: Install dependencies
         run: npm ci
@@ -37,15 +36,18 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
+      # Linux: same setup script used by the Docker build image.
+      - name: Set up build environment
+        if: runner.os == 'Linux'
+        run: sudo ./build/appimage/setup-build-env.sh
+
+      # Windows: no shared script yet; native setup.
       - name: Setup Node.js
+        if: runner.os == 'Windows'
         uses: actions/setup-node@v4
         with:
           node-version: '20'
           cache: 'npm'
-
-      - name: Install squashfs-tools (Linux)
-        if: runner.os == 'Linux'
-        run: sudo apt-get update && sudo apt-get install -y squashfs-tools
 
       - name: Install dependencies
         run: npm ci

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -24,15 +24,18 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
 
+      # Linux: same setup script used by the Docker build image.
+      - name: Set up build environment
+        if: runner.os == 'Linux'
+        run: sudo ./build/appimage/setup-build-env.sh
+
+      # Windows: no shared script yet; native setup.
       - name: Setup Node.js
+        if: runner.os == 'Windows'
         uses: actions/setup-node@v4
         with:
           node-version: '20'
           cache: 'npm'
-
-      - name: Install squashfs-tools (Linux)
-        if: runner.os == 'Linux'
-        run: sudo apt-get update && sudo apt-get install -y squashfs-tools
 
       - name: Install dependencies
         run: npm ci

--- a/.gitignore
+++ b/.gitignore
@@ -41,3 +41,13 @@ out/
 
 # Biome server seeds cache when running dev mode
 world_engine/
+
+# AppImage post-processing: downloaded tools (linuxdeploy, appimagetool) and
+# the bundled Zig toolchain extracted for packaging. Populated on Linux
+# builds by scripts/appimage-prepare-assets.mjs.
+build/appimage/.cache/
+build/appimage/toolchain/
+
+# Logs produced from inside the appimage-docker-desktop.sh test container's
+# /out mount. Useful for capturing AppImage stdout/stderr without docker exec.
+out/appimage-test-out/

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -145,7 +145,45 @@ Electron Forge with Vite plugin. Three separate Vite configs and tsconfigs:
 
 **Local builds**: `npm run build` copies `server-components/` and other extra resource directories verbatim into the installer. Make sure your workspace is clean before building — any untracked files (`.venv`, `__pycache__`, `uv.lock`, `server.log`, etc.) will be included and can bloat the installer by gigabytes. Production releases should be cut via CI from a clean checkout.
 
-**Linux builds**: The AppImage maker requires `mksquashfs` (from squashfs-tools) to be on `PATH`. On NixOS, this is provided by `shell.nix`. On Ubuntu/Debian, install `squashfs-tools`.
+**Linux AppImage builds**: The default AppImage produced by `@reforged/maker-appimage` is a thin wrapper — it relies on the host system having GTK3, X11, NSS, a C toolchain (for Triton's runtime CUDA JIT), and a correctly-configured OpenSSL. In practice, this fails on many distros: OpenSuSE Tumbleweed crashes on OpenSSL config ([#92](https://github.com/Overworldai/Biome/issues/92)), NixOS has none of these at standard FHS paths, and most desktop Linux installs don't ship `gcc`. Our post-processing pipeline turns the bare AppImage into a self-contained bundle that works across distributions.
+
+On Linux, `npm run build` produces an AppImage that is then post-processed by `scripts/appimage-post-make.mjs` (called automatically via Forge's `postMake` hook). The pipeline:
+
+1. **Fetches build tools** (`scripts/appimage-prepare-assets.mjs`, run via Forge `generateAssets` hook): downloads pinned versions of [linuxdeploy](https://github.com/linuxdeploy/linuxdeploy), linuxdeploy-plugin-gtk, [appimagetool](https://github.com/AppImage/appimagetool), and the [Zig](https://ziglang.org/) toolchain into `build/appimage/.cache/` and `build/appimage/toolchain/`. Idempotent; skips assets already present. SHA256 hashes are pinned in the script — CI refuses to proceed without them.
+2. **Bundles GTK/X11 deps**: linuxdeploy + plugin-gtk walk the Electron binary's ELF dependencies and copy ~130 shared libraries into the AppDir, with rpath patching.
+3. **Bundles transitive closure**: a second pass uses `ldd` to find libs that linuxdeploy's excludelist skipped (libX11, libxcb, libz, etc.) and copies them too. This ensures the AppImage works on distros with non-FHS layouts (NixOS, Alpine).
+4. **Bundles NSS plugins**: `libsoftokn3.so` and friends are dlopen'd by Chromium at runtime — invisible to `ldd` — so they're copied explicitly.
+5. **Installs Zig toolchain**: Zig is copied into `AppDir/toolchain/` with `cc`/`gcc`/`clang` shim symlinks. Triton JIT-compiles CUDA launcher stubs at runtime with `cc`; most user systems don't have a C toolchain installed, so the AppImage ships one. The shim rewrites `-l:libfoo.so.N` → `-lfoo` to work around zig's lld not supporting the GNU `-l:` extension.
+6. **Installs AppRun wrapper** (`build/appimage/AppRun`): replaces the default symlink with a shell script that sets `LD_LIBRARY_PATH` for bundled libs, `OPENSSL_CONF=/dev/null` (see [Overworldai/Biome#92](https://github.com/Overworldai/Biome/issues/92)), detects the host's `libcuda.so` path, exposes the Zig toolchain on `$PATH`, sources linuxdeploy-plugin-gtk hooks, and execs the Electron binary.
+7. **Fixes up .desktop entry**: injects `Categories=Game;` and `Icon=biome` (appimagetool requires both).
+8. **Re-squashes** the modified AppDir with appimagetool.
+
+Build-time apt dependencies are listed in `build/appimage/apt-deps.txt`, installed via `build/appimage/setup-build-env.sh` — a single script that sets up the entire Linux build environment (Node.js 20 via NodeSource + apt deps). Both CI and the Docker build image (`build/appimage/Dockerfile`) run this same script, so there's exactly one definition of what the Linux build needs.
+
+**Building the AppImage locally** (requires Docker):
+
+```bash
+./scripts/appimage-docker-build.sh           # Build inside an ubuntu-22.04 container
+./scripts/appimage-docker-build.sh --rebuild # Force image rebuild (e.g. after changing apt-deps.txt)
+```
+
+Output: `out/make/AppImage/x64/Biome-<version>-x64.AppImage`.
+
+**Testing the AppImage** (requires Docker + NVIDIA GPU):
+
+```bash
+./scripts/appimage-docker-desktop.sh                  # Ubuntu 24.04 (default)
+./scripts/appimage-docker-desktop.sh --distro fedora  # Fedora 41
+./scripts/appimage-docker-desktop.sh --distro arch    # Arch Linux
+./scripts/appimage-docker-desktop.sh --no-gpu         # Skip GPU passthrough
+./scripts/appimage-docker-desktop.sh --rebuild        # Force image rebuild
+```
+
+Opens a Wayland desktop (sway + wayvnc + noVNC) at http://localhost:6080/. The AppImage runs in a real Wayland session so Electron uses Ozone-Wayland, matching the default display server on modern Ubuntu/Fedora. Inside the terminal, type `biome` to launch. Logs are written to `out/appimage-test-out/biome.log` on the host. GPU is passed through via CDI on NixOS (`hardware.nvidia-container-toolkit.enable = true`) or via the legacy nvidia runtime on other distros. Bazzite is Fedora-based, so `--distro fedora` covers it.
+
+**Updating pinned tool versions**: null out the SHA256 constant in `scripts/appimage-prepare-assets.mjs`, re-run the script (it logs the new hash), paste it back. CI enforces all hashes are pinned.
+
+**NixOS note**: the AppImage requires `appimage-run` for direct launch on NixOS due to Chromium's DBus init crashing outside a FHS environment. The Docker-based test script avoids this by running inside a real Ubuntu desktop.
 
 ## Code Style
 

--- a/build/appimage-test/Dockerfile
+++ b/build/appimage-test/Dockerfile
@@ -1,0 +1,22 @@
+# Containerised Wayland desktop for end-to-end testing the AppImage.
+# Parameterised by distro: --build-arg DISTRO_FAMILY={ubuntu,fedora,arch}.
+# Uses sway (headless) + wayvnc + noVNC for browser-based access.
+
+ARG BASE_IMAGE=ubuntu:24.04
+FROM $BASE_IMAGE
+
+ARG DISTRO_FAMILY=ubuntu
+ENV LANG=C.UTF-8
+
+# Per-distro package installation (sway, wayvnc, terminal, etc.)
+COPY setup-${DISTRO_FAMILY}.sh /tmp/setup-distro.sh
+RUN chmod +x /tmp/setup-distro.sh && /tmp/setup-distro.sh
+
+COPY start.sh /usr/local/bin/start.sh
+COPY biome /usr/local/bin/biome
+COPY sway-config /etc/sway/config.d/biome
+RUN chmod +x /usr/local/bin/start.sh /usr/local/bin/biome
+
+EXPOSE 5900 6080
+
+CMD ["/usr/local/bin/start.sh"]

--- a/build/appimage-test/biome
+++ b/build/appimage-test/biome
@@ -1,0 +1,18 @@
+#!/bin/sh
+# Helper for launching Biome inside the test container.
+#
+#   biome              # default flags, streamed and appended to /out/biome.log
+#   biome --some-flag  # extra flags pass through
+#
+# Output is teed to /out/biome.log so it's readable from the host at
+# out/appimage-test-out/biome.log without docker exec.
+
+set -e
+
+LOG=/out/biome.log
+{
+  echo
+  echo "=== $(date -Iseconds) biome ${*:-(no extra args)} ==="
+} >> "$LOG"
+
+/shared/Biome.AppImage --no-sandbox "$@" 2>&1 | tee -a "$LOG"

--- a/build/appimage-test/setup-arch.sh
+++ b/build/appimage-test/setup-arch.sh
@@ -1,0 +1,24 @@
+#!/bin/sh
+set -eu
+
+# Initialize keyring (Arch Docker images can have stale keys).
+pacman-key --init
+pacman-key --populate archlinux
+pacman -Syu --noconfirm
+
+pacman -S --noconfirm --needed \
+  sway wayvnc foot \
+  python python-pip \
+  mesa xorg-xwayland
+
+# websockify: install via pip (not always in official repos).
+pip install --break-system-packages websockify
+
+# noVNC: not in official repos — fetch the release tarball.
+NOVNC_VERSION=1.5.0
+curl -fsSL "https://github.com/novnc/noVNC/archive/refs/tags/v${NOVNC_VERSION}.tar.gz" \
+  | tar xz -C /opt
+ln -sf "/opt/noVNC-${NOVNC_VERSION}" /opt/novnc
+ln -sf vnc.html /opt/novnc/index.html
+
+pacman -Scc --noconfirm

--- a/build/appimage-test/setup-fedora.sh
+++ b/build/appimage-test/setup-fedora.sh
@@ -1,0 +1,9 @@
+#!/bin/sh
+set -eu
+dnf install -y \
+  sway wayvnc foot \
+  novnc python3-websockify \
+  dbus-x11 gnome-terminal nautilus \
+  mesa-libGL mesa-demos xorg-x11-server-Xwayland
+ln -sf vnc.html /usr/share/novnc/index.html
+dnf clean all

--- a/build/appimage-test/setup-ubuntu.sh
+++ b/build/appimage-test/setup-ubuntu.sh
@@ -1,0 +1,12 @@
+#!/bin/sh
+set -eu
+export DEBIAN_FRONTEND=noninteractive
+apt-get update
+apt-get install -y --no-install-recommends \
+  sway wayvnc foot \
+  novnc websockify \
+  dbus-x11 gnome-terminal nautilus \
+  libgl1 mesa-utils xwayland ca-certificates
+ln -sf vnc.html /usr/share/novnc/index.html
+apt-get clean
+rm -rf /var/lib/apt/lists/*

--- a/build/appimage-test/start.sh
+++ b/build/appimage-test/start.sh
@@ -1,0 +1,64 @@
+#!/bin/sh
+# Entrypoint for the appimage-test container.
+# Starts sway (Wayland, headless) + wayvnc + noVNC websockify bridge.
+
+set -e
+
+VNC_PASSWORD="${VNC_PASSWORD:-biome}"
+
+export XDG_RUNTIME_DIR="${XDG_RUNTIME_DIR:-/tmp/xdg-runtime}"
+mkdir -p "$XDG_RUNTIME_DIR"
+chmod 700 "$XDG_RUNTIME_DIR"
+
+# sway headless: no physical display or input devices. If a GPU is present
+# (CDI passthrough), wlroots uses its EGL; otherwise falls back to pixman.
+export WLR_BACKENDS=headless
+export WLR_LIBINPUT_NO_DEVICES=1
+
+echo "[appimage-desktop] starting sway (Wayland, headless)"
+sway &
+SWAY_PID=$!
+
+# Wait for the Wayland socket.
+WAYLAND_SOCKET="$XDG_RUNTIME_DIR/wayland-1"
+for i in $(seq 1 30); do
+  [ -S "$WAYLAND_SOCKET" ] && break
+  sleep 0.2
+done
+if [ ! -S "$WAYLAND_SOCKET" ]; then
+  echo "[appimage-desktop] error: sway did not create $WAYLAND_SOCKET" >&2
+  exit 1
+fi
+export WAYLAND_DISPLAY=wayland-1
+
+echo "[appimage-desktop] starting wayvnc on :5900"
+wayvnc 0.0.0.0 5900 &
+WAYVNC_PID=$!
+sleep 1
+
+# noVNC: distro packages put it at /usr/share/novnc; Arch setup fetches
+# it to /opt/novnc. Find whichever is present.
+NOVNC_DIR=""
+for d in /usr/share/novnc /opt/novnc; do
+  [ -d "$d" ] && NOVNC_DIR="$d" && break
+done
+if [ -z "$NOVNC_DIR" ]; then
+  echo "[appimage-desktop] warning: noVNC not found; browser access unavailable" >&2
+else
+  echo "[appimage-desktop] starting noVNC websockify on 6080"
+  websockify --web "$NOVNC_DIR" 6080 localhost:5900 &
+fi
+WEBSOCKIFY_PID=$!
+
+cat <<EOF
+
+[appimage-desktop] desktop ready (Wayland via sway).
+  noVNC (browser): http://localhost:6080/
+  Direct VNC:      vnc://localhost:5900
+
+  Inside the terminal, run:  biome
+  Logs: /out/biome.log (host: out/appimage-test-out/)
+
+EOF
+
+wait "$SWAY_PID" "$WEBSOCKIFY_PID" "$WAYVNC_PID" 2>/dev/null || true

--- a/build/appimage-test/sway-config
+++ b/build/appimage-test/sway-config
@@ -1,0 +1,8 @@
+# Biome test container sway overrides.
+# Loaded from /etc/sway/config.d/ alongside the distro defaults.
+
+# Virtual output for headless mode (wayvnc attaches to this).
+output HEADLESS-1 resolution 1600x1000
+
+# Launch a terminal on startup so the user has something to type into.
+exec gnome-terminal

--- a/build/appimage/AppRun
+++ b/build/appimage/AppRun
@@ -1,0 +1,66 @@
+#!/bin/sh
+# Biome AppImage launcher — sets up LD_LIBRARY_PATH for bundled libs,
+# env shims (OpenSSL, libcuda, zig toolchain), sources GTK hooks, then
+# execs the Electron binary.
+#
+# No `set -u`: sourced apprun-hooks reference unguarded env vars like
+# $XDG_DATA_DIRS that may be unset on minimal systems.
+set -e
+
+APPDIR="${APPDIR:-$(cd "$(dirname "$(readlink -f "$0")")" && pwd)}"
+export APPDIR
+
+# Bundled shared libs (linuxdeploy puts them in usr/lib; the Electron
+# binary's own rpath only covers usr/lib/biome).
+export LD_LIBRARY_PATH="$APPDIR/usr/lib${LD_LIBRARY_PATH:+:$LD_LIBRARY_PATH}"
+
+# Neutralise host OpenSSL config — see Overworldai/Biome#92.
+export OPENSSL_CONF=/dev/null
+
+# libcuda must come from the host (paired with the kernel driver).
+if [ -z "${BIOME_LIBCUDA_DIR:-}" ]; then
+  for d in \
+    /run/opengl-driver/lib \
+    /usr/lib/x86_64-linux-gnu \
+    /usr/lib64 \
+    /usr/lib; do
+    if [ -e "$d/libcuda.so.1" ] || [ -e "$d/libcuda.so" ]; then
+      BIOME_LIBCUDA_DIR="$d"
+      break
+    fi
+  done
+
+  if [ -z "${BIOME_LIBCUDA_DIR:-}" ] && command -v ldconfig >/dev/null 2>&1; then
+    _cuda_path="$(ldconfig -p 2>/dev/null | awk '/libcuda\.so\.1/ {print $NF; exit}')"
+    if [ -n "$_cuda_path" ]; then
+      BIOME_LIBCUDA_DIR="$(dirname "$_cuda_path")"
+    fi
+  fi
+fi
+
+if [ -n "${BIOME_LIBCUDA_DIR:-}" ]; then
+  export TRITON_LIBCUDA_PATH="$BIOME_LIBCUDA_DIR"
+  export LD_LIBRARY_PATH="$BIOME_LIBCUDA_DIR:$LD_LIBRARY_PATH"
+fi
+
+# Bundled zig-cc toolchain for Triton's runtime JIT.
+TOOLCHAIN_ROOT="$APPDIR/toolchain"
+if [ -x "$TOOLCHAIN_ROOT/shim/cc" ] && [ -x "$TOOLCHAIN_ROOT/zig/zig" ]; then
+  export PATH="$TOOLCHAIN_ROOT/shim:$TOOLCHAIN_ROOT/zig:$PATH"
+fi
+
+# Source linuxdeploy-plugin-gtk env hooks (GTK modules, schemas, pixbuf).
+if [ -d "$APPDIR/apprun-hooks" ]; then
+  for hook in "$APPDIR/apprun-hooks"/*.sh; do
+    [ -f "$hook" ] || continue
+    # shellcheck disable=SC1090
+    . "$hook"
+  done
+fi
+
+BIOME_BIN="$APPDIR/usr/bin/biome"
+if [ ! -x "$BIOME_BIN" ]; then
+  echo "AppRun: $BIOME_BIN not found or not executable" >&2
+  exit 1
+fi
+exec "$BIOME_BIN" "$@"

--- a/build/appimage/Dockerfile
+++ b/build/appimage/Dockerfile
@@ -1,0 +1,25 @@
+# Docker build image for the Biome AppImage. Setup is delegated to
+# setup-build-env.sh (shared with CI), split into stages for layer caching.
+
+FROM ubuntu:22.04
+
+# Stage 1: bootstrap (ca-certificates, curl, gnupg).
+# Only re-runs when setup-build-env.sh itself changes.
+COPY build/appimage/setup-build-env.sh /opt/biome-appimage/
+RUN chmod +x /opt/biome-appimage/setup-build-env.sh \
+    && /opt/biome-appimage/setup-build-env.sh bootstrap
+
+# Stage 2: Node.js 20 via NodeSource.
+# Only re-runs when setup-build-env.sh changes.
+RUN /opt/biome-appimage/setup-build-env.sh node
+
+# Stage 3: AppImage build deps from apt-deps.txt.
+# Re-runs when apt-deps.txt or install-apt-deps.sh change.
+COPY build/appimage/apt-deps.txt build/appimage/install-apt-deps.sh /opt/biome-appimage/
+RUN chmod +x /opt/biome-appimage/install-apt-deps.sh \
+    && /opt/biome-appimage/setup-build-env.sh deps \
+    && rm -rf /var/lib/apt/lists/*
+
+WORKDIR /workspace
+
+CMD ["bash", "-c", "npm ci && npm run build"]

--- a/build/appimage/apt-deps.txt
+++ b/build/appimage/apt-deps.txt
@@ -1,0 +1,38 @@
+# Apt deps for the Biome AppImage build. Shared by CI and Docker.
+
+# --- AppImage tooling ---
+squashfs-tools
+patchelf
+file
+
+# --- linuxdeploy-plugin-gtk helpers ---
+# dpkg-architecture (from dpkg-dev), pkg-config, glib-compile-schemas (from
+# libglib2.0-bin) and gdk-pixbuf-query-loaders (from libgdk-pixbuf2.0-bin) are
+# invoked by the plugin at run time; the -dev packages provide the .pc files
+# the plugin queries with pkg-config.
+dpkg-dev
+pkg-config
+libglib2.0-bin
+libglib2.0-dev
+libgdk-pixbuf2.0-bin
+libgdk-pixbuf-2.0-dev
+librsvg2-common
+
+# --- Electron runtime shared libraries ---
+libglib2.0-0
+libgtk-3-0
+libnss3
+libnspr4
+libatk1.0-0
+libatk-bridge2.0-0
+libcups2
+libdrm2
+libgbm1
+libxkbcommon0
+libxshmfence1
+libatspi2.0-0
+libasound2
+libpango-1.0-0
+libpangocairo-1.0-0
+libcairo2
+libexpat1

--- a/build/appimage/cc-shim
+++ b/build/appimage/cc-shim
@@ -1,0 +1,38 @@
+#!/bin/sh
+# Bundled C-compiler shim: routes cc/gcc/clang → zig cc, c++/g++/clang++ → zig c++.
+# Rewrites `-l:libfoo.so.N` → `-lfoo` because zig's lld doesn't support the
+# GNU `-l:` extension (Triton hardcodes `-l:libcuda.so.1`).
+
+set -e
+
+SHIM_DIR="$(cd "$(dirname "$(readlink -f "$0")")" && pwd)"
+ZIG="$SHIM_DIR/../zig/zig"
+
+# Walk the original argv exactly $# times: at each step, shift the head
+# and append either it or its rewritten form to the tail. After $# loops,
+# $@ contains the rewritten args in order with the originals consumed.
+n=$#
+i=0
+while [ $i -lt $n ]; do
+  case "$1" in
+    -l:lib*.so*)
+      stem=${1#-l:lib}
+      stem=${stem%%.so*}
+      set -- "$@" "-l$stem"
+      ;;
+    *)
+      set -- "$@" "$1"
+      ;;
+  esac
+  shift
+  i=$((i + 1))
+done
+
+case "$(basename "$0")" in
+  c++ | g++ | clang++ | cxx)
+    exec "$ZIG" c++ "$@"
+    ;;
+  *)
+    exec "$ZIG" cc "$@"
+    ;;
+esac

--- a/build/appimage/install-apt-deps.sh
+++ b/build/appimage/install-apt-deps.sh
@@ -1,0 +1,35 @@
+#!/bin/sh
+# Install Biome AppImage build dependencies from apt-deps.txt.
+# Idempotent; re-runs apt-get update + install.
+#
+# Invokes sudo only if not already root — lets the same script drop into
+# CI runners (which need sudo) and Docker containers (which run as root).
+
+set -eu
+
+SCRIPT_DIR="$(cd "$(dirname "$(readlink -f "$0")")" && pwd)"
+DEPS_FILE="$SCRIPT_DIR/apt-deps.txt"
+
+if [ ! -r "$DEPS_FILE" ]; then
+  echo "error: cannot read $DEPS_FILE" >&2
+  exit 1
+fi
+
+# Collect package names (strip comments and blank lines).
+PACKAGES="$(grep -vE '^\s*(#|$)' "$DEPS_FILE" | tr '\n' ' ')"
+
+if [ -z "$PACKAGES" ]; then
+  echo "error: no packages listed in $DEPS_FILE" >&2
+  exit 1
+fi
+
+if [ "$(id -u)" -eq 0 ]; then
+  SUDO=""
+else
+  SUDO="sudo"
+fi
+
+export DEBIAN_FRONTEND=noninteractive
+$SUDO apt-get update
+# shellcheck disable=SC2086 # intentional word-splitting of PACKAGES
+$SUDO apt-get install -y --no-install-recommends $PACKAGES

--- a/build/appimage/setup-build-env.sh
+++ b/build/appimage/setup-build-env.sh
@@ -1,0 +1,48 @@
+#!/bin/sh
+# Set up the Linux build environment for the Biome AppImage.
+#
+# Single source of truth for both:
+#   - The Docker build image (calls with stage args for layer caching)
+#   - The CI workflow (calls with no args → runs all stages)
+#
+# Usage:
+#   setup-build-env.sh              # all stages (CI)
+#   setup-build-env.sh bootstrap    # just ca-certificates, curl, gnupg
+#   setup-build-env.sh node         # just Node.js 20 via NodeSource
+#   setup-build-env.sh deps         # just AppImage build deps (apt-deps.txt)
+
+set -eu
+
+SCRIPT_DIR="$(cd "$(dirname "$(readlink -f "$0")")" && pwd)"
+STAGE="${1:-all}"
+
+if [ "$(id -u)" -ne 0 ]; then
+  echo "error: must run as root (try: sudo $0)" >&2
+  exit 1
+fi
+
+export DEBIAN_FRONTEND=noninteractive
+
+run_bootstrap() {
+  apt-get update
+  apt-get install -y --no-install-recommends ca-certificates curl gnupg
+}
+
+run_node() {
+  if ! node --version 2>/dev/null | grep -q '^v20\.'; then
+    curl -fsSL https://deb.nodesource.com/setup_20.x | bash -
+    apt-get install -y --no-install-recommends nodejs
+  fi
+}
+
+run_deps() {
+  "$SCRIPT_DIR/install-apt-deps.sh"
+}
+
+case "$STAGE" in
+  all)       run_bootstrap; run_node; run_deps ;;
+  bootstrap) run_bootstrap ;;
+  node)      run_node ;;
+  deps)      run_deps ;;
+  *) echo "error: unknown stage '$STAGE' (bootstrap, node, deps)" >&2; exit 2 ;;
+esac

--- a/electron/ipc/server.ts
+++ b/electron/ipc/server.ts
@@ -5,7 +5,7 @@ import fs from 'node:fs'
 import net from 'node:net'
 import path from 'node:path'
 import { getEngineDir, getUvDir, getHfHomeDir, getHfHubCacheDir } from '../lib/paths.js'
-import { getUvBinaryPath, getUvEnvVars } from '../lib/uv.js'
+import { getUvBinaryPath, getUvEnvVars, getBundledPythonIncludeDir } from '../lib/uv.js'
 import { getHiddenWindowOptions } from '../lib/platform.js'
 import {
   getServerState,
@@ -65,6 +65,16 @@ export function registerServerIpc(): void {
       PYTHONUNBUFFERED: '1',
       PYTHONFAULTHANDLER: '1',
       BIOME_SERVER_LOG_PATH: path.join(engineDir, 'server.log')
+    }
+
+    // Point the in-venv C compiler at the uv-managed Python headers so Triton's
+    // runtime JIT can #include <Python.h>. python-build-standalone's sysconfig
+    // reports an incorrect include path on NixOS; this override also helps
+    // users on distros where the system Python headers are absent.
+    const pythonIncludeDir = getBundledPythonIncludeDir()
+    if (pythonIncludeDir) {
+      const existingCPath = serverEnv.C_INCLUDE_PATH
+      serverEnv.C_INCLUDE_PATH = existingCPath ? `${pythonIncludeDir}:${existingCPath}` : pythonIncludeDir
     }
 
     // Create log file path

--- a/electron/lib/uv.ts
+++ b/electron/lib/uv.ts
@@ -1,5 +1,5 @@
+import fs from 'node:fs'
 import path from 'node:path'
-import type { SpawnOptions } from 'node:child_process'
 import { getUvDir } from './paths.js'
 import { getUvBinaryName } from './platform.js'
 
@@ -11,7 +11,7 @@ export function getUvBinaryPath(): string {
 /** Get the common uv environment variables */
 export function getUvEnvVars(): Record<string, string> {
   const uvDir = getUvDir()
-  return {
+  const env: Record<string, string> = {
     UV_CACHE_DIR: path.join(uvDir, 'cache'),
     UV_NO_CONFIG: '1',
     UV_PYTHON_INSTALL_DIR: path.join(uvDir, 'python_install'),
@@ -23,4 +23,51 @@ export function getUvEnvVars(): Record<string, string> {
     UV_NO_EDITABLE: '1',
     UV_MANAGED_PYTHON: '1'
   }
+
+  // On Linux, the uv-managed Python's bundled OpenSSL reads the host's
+  // OPENSSL_CONF and can crash on configs it doesn't understand (e.g. OpenSuSE
+  // Tumbleweed, see Overworldai/Biome#92). Neutralise it by pointing at an
+  // empty file. The AppRun wrapper also sets this, but we duplicate it here so
+  // dev-mode Linux and non-AppImage Linux packages (if we add them later) get
+  // the same protection.
+  if (process.platform === 'linux') {
+    env.OPENSSL_CONF = '/dev/null'
+  }
+
+  return env
+}
+
+/**
+ * Resolve the include dir for the uv-managed Python 3.12 install, if present.
+ *
+ * Triton JIT-compiles CUDA launcher stubs at runtime and needs `Python.h`.
+ * uv uses python-build-standalone, whose sysconfig on NixOS mis-reports the
+ * include path as /run/current-system/sw/include/... — hence the workaround
+ * in shell.nix. Pointing `C_INCLUDE_PATH` at the real bundled headers fixes
+ * it universally (NixOS and AppImage users with distro-local gcc).
+ *
+ * Returns null if the python_install dir doesn't exist yet (pre-setup) or
+ * doesn't match the expected layout.
+ */
+export function getBundledPythonIncludeDir(): string | null {
+  if (process.platform === 'win32') return null
+
+  const pythonInstallRoot = path.join(getUvDir(), 'python_install')
+  if (!fs.existsSync(pythonInstallRoot)) return null
+
+  let entries: string[]
+  try {
+    entries = fs.readdirSync(pythonInstallRoot)
+  } catch {
+    return null
+  }
+
+  // Match cpython-3.12.*-<arch>-<os>-<abi>, e.g. cpython-3.12.13-linux-x86_64-gnu.
+  const match = entries.find((name) => /^cpython-3\.12\./.test(name))
+  if (!match) return null
+
+  const includeDir = path.join(pythonInstallRoot, match, 'include', 'python3.12')
+  if (!fs.existsSync(path.join(includeDir, 'Python.h'))) return null
+
+  return includeDir
 }

--- a/forge.config.ts
+++ b/forge.config.ts
@@ -3,6 +3,11 @@ import { VitePlugin } from '@electron-forge/plugin-vite'
 import MakerNSIS from '@felixrieseberg/electron-forge-maker-nsis'
 import { MakerDMG } from '@electron-forge/maker-dmg'
 import { MakerAppImage } from '@reforged/maker-appimage'
+import { spawnSync } from 'node:child_process'
+import { fileURLToPath } from 'node:url'
+import { dirname, resolve } from 'node:path'
+
+const __dirname = dirname(fileURLToPath(import.meta.url))
 
 const config: ForgeConfig = {
   packagerConfig: {
@@ -62,7 +67,31 @@ const config: ForgeConfig = {
         }
       ]
     })
-  ]
+  ],
+  hooks: {
+    // Fetch AppImage post-processing tools (linuxdeploy, appimagetool, zig).
+    // Idempotent — skips items already in build/appimage/.cache or toolchain/.
+    // Only does work on Linux builds.
+    generateAssets: async (_config, platform) => {
+      if (platform !== 'linux') return
+      runNodeScript('scripts/appimage-prepare-assets.mjs')
+    },
+    // Post-process the produced .AppImage: bundle GTK/X11 deps via linuxdeploy,
+    // install the Zig toolchain + AppRun wrapper, re-squash with appimagetool.
+    postMake: async (_config, makeResults) => {
+      if (process.platform !== 'linux') return makeResults
+      const mod = await import('./scripts/appimage-post-make.mjs')
+      return await mod.default(makeResults)
+    }
+  }
+}
+
+function runNodeScript(relativePath: string): void {
+  const scriptPath = resolve(__dirname, relativePath)
+  const result = spawnSync(process.execPath, [scriptPath], { stdio: 'inherit' })
+  if (result.status !== 0) {
+    throw new Error(`${relativePath} exited with status ${result.status}`)
+  }
 }
 
 export default config

--- a/scripts/appimage-docker-build.sh
+++ b/scripts/appimage-docker-build.sh
@@ -1,0 +1,66 @@
+#!/usr/bin/env bash
+# Build the Biome AppImage inside a Docker container that mirrors the
+# GitHub Actions environment (ubuntu-22.04 + Node 20 + the shared apt
+# package list from build/appimage/apt-deps.txt).
+#
+# Output lands in ./out/make/ on the host (same path as `npm run build`).
+#
+# Usage:
+#   ./scripts/appimage-docker-build.sh           # build with cached image
+#   ./scripts/appimage-docker-build.sh --rebuild # force docker build --no-cache
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$(readlink -f "$0")")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+
+IMAGE_TAG="biome-appimage-builder:ubuntu-22.04"
+DOCKERFILE="$REPO_ROOT/build/appimage/Dockerfile"
+
+BUILD_FLAGS=()
+for arg in "$@"; do
+  case "$arg" in
+    --rebuild) BUILD_FLAGS+=(--no-cache) ;;
+    -h|--help)
+      sed -n '2,10p' "$0"
+      exit 0
+      ;;
+    *)
+      echo "unknown argument: $arg" >&2
+      exit 2
+      ;;
+  esac
+done
+
+if ! command -v docker >/dev/null 2>&1; then
+  echo "error: docker not found on PATH" >&2
+  exit 1
+fi
+
+echo "[docker-build] building image $IMAGE_TAG"
+docker build \
+  "${BUILD_FLAGS[@]}" \
+  -f "$DOCKERFILE" \
+  -t "$IMAGE_TAG" \
+  "$REPO_ROOT"
+
+echo "[docker-build] running build inside container"
+# Notes on flags:
+#   -u $UID:$GID          run as host user so out/ and build/appimage/.cache/
+#                         stay owned by the invoker, not root.
+#   -e HOME=/tmp/home     npm, npx, uv etc. need a writable HOME; /tmp/home
+#                         is created at run time inside the container.
+#   --init                reap zombie processes (node-gyp, electron-rebuild).
+docker run --rm \
+  --init \
+  -u "$(id -u):$(id -g)" \
+  -e HOME=/tmp/home \
+  -e CI=1 \
+  -v "$REPO_ROOT":/workspace \
+  -w /workspace \
+  "$IMAGE_TAG" \
+  bash -c 'mkdir -p /tmp/home && npm ci && npm run build'
+
+echo "[docker-build] done."
+echo "artifacts:"
+find "$REPO_ROOT/out/make" -maxdepth 4 -name '*.AppImage' -print 2>/dev/null || true

--- a/scripts/appimage-docker-desktop.sh
+++ b/scripts/appimage-docker-desktop.sh
@@ -1,0 +1,123 @@
+#!/usr/bin/env bash
+# Test the built AppImage inside a containerised Wayland desktop.
+# Uses sway (headless) + wayvnc + noVNC for browser-based access.
+#
+# Usage:
+#   ./scripts/appimage-docker-desktop.sh                  # ubuntu (default)
+#   ./scripts/appimage-docker-desktop.sh --distro fedora  # fedora 41
+#   ./scripts/appimage-docker-desktop.sh --distro arch    # archlinux
+#   ./scripts/appimage-docker-desktop.sh --no-gpu         # skip GPU passthrough
+#   ./scripts/appimage-docker-desktop.sh --rebuild        # docker build --no-cache
+#   ./scripts/appimage-docker-desktop.sh --port 6080      # change noVNC port
+#
+# Open http://localhost:6080/ and type `biome` in the terminal.
+# Ctrl-C here to stop.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$(readlink -f "$0")")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+
+DOCKERFILE="$REPO_ROOT/build/appimage-test/Dockerfile"
+DOCKER_CONTEXT="$REPO_ROOT/build/appimage-test"
+
+DISTRO="ubuntu"
+USE_GPU=1
+REBUILD=0
+NOVNC_PORT=6080
+VNC_PASSWORD="${VNC_PASSWORD:-biome}"
+
+while [ $# -gt 0 ]; do
+  case "$1" in
+    --distro)   DISTRO="$2"; shift 2 ;;
+    --no-gpu)   USE_GPU=0; shift ;;
+    --rebuild)  REBUILD=1; shift ;;
+    --port)     NOVNC_PORT="$2"; shift 2 ;;
+    -h|--help)  sed -n '2,13p' "$0"; exit 0 ;;
+    *) echo "unknown argument: $1" >&2; exit 2 ;;
+  esac
+done
+
+# Map --distro to Docker base image and distro-family build arg.
+case "$DISTRO" in
+  ubuntu)  BASE_IMAGE="ubuntu:24.04";      DISTRO_FAMILY="ubuntu" ;;
+  fedora)  BASE_IMAGE="fedora:41";          DISTRO_FAMILY="fedora" ;;
+  arch)    BASE_IMAGE="archlinux:latest";   DISTRO_FAMILY="arch" ;;
+  *) echo "error: unknown distro '$DISTRO' (ubuntu, fedora, arch)" >&2; exit 2 ;;
+esac
+
+IMAGE_TAG="biome-appimage-desktop:$DISTRO"
+
+if ! command -v docker >/dev/null 2>&1; then
+  echo "error: docker not found on PATH" >&2
+  exit 1
+fi
+
+APPIMAGE_DIR="$REPO_ROOT/out/make/AppImage/x64"
+APPIMAGE_PATH="$(ls -t "$APPIMAGE_DIR"/*.AppImage 2>/dev/null | head -1 || true)"
+if [ -z "$APPIMAGE_PATH" ]; then
+  echo "error: no .AppImage found in $APPIMAGE_DIR — run ./scripts/appimage-docker-build.sh first" >&2
+  exit 1
+fi
+echo "[appimage-desktop] $DISTRO | $(basename "$APPIMAGE_PATH")"
+
+BUILD_FLAGS=(
+  --build-arg "BASE_IMAGE=$BASE_IMAGE"
+  --build-arg "DISTRO_FAMILY=$DISTRO_FAMILY"
+)
+[ "$REBUILD" = 1 ] && BUILD_FLAGS+=(--no-cache)
+echo "[appimage-desktop] building image $IMAGE_TAG"
+docker build "${BUILD_FLAGS[@]}" -f "$DOCKERFILE" -t "$IMAGE_TAG" "$DOCKER_CONTEXT"
+
+LOGS_DIR="$REPO_ROOT/out/appimage-test-out"
+mkdir -p "$LOGS_DIR"
+
+DOCKER_FLAGS=(
+  --rm -it
+  --name biome-appimage-desktop
+  -p "127.0.0.1:$NOVNC_PORT:6080"
+  -p "127.0.0.1:5900:5900"
+  -v "$APPIMAGE_PATH":/shared/Biome.AppImage:ro
+  -v "$LOGS_DIR":/out
+  -e VNC_PASSWORD="$VNC_PASSWORD"
+  -e APPIMAGE_EXTRACT_AND_RUN=1
+  --shm-size=2g
+  # sway/wlroots needs SYS_NICE for thread priorities. Without it the
+  # compositor fails with "Operation not permitted" at startup.
+  --cap-add=SYS_NICE
+)
+
+# GPU passthrough: prefer CDI (modern NixOS), fall back to legacy --gpus.
+if [ "$USE_GPU" = 1 ]; then
+  HAS_CDI=0
+  for d in /etc/cdi /var/run/cdi; do
+    [ -d "$d" ] || continue
+    for f in "$d"/*.yaml "$d"/*.json; do
+      if [ -e "$f" ]; then HAS_CDI=1; break 2; fi
+    done
+  done
+
+  if [ "$HAS_CDI" = 1 ]; then
+    DOCKER_FLAGS+=(--device nvidia.com/gpu=all)
+    echo "[appimage-desktop] GPU via CDI"
+  elif docker info 2>/dev/null | grep -q nvidia; then
+    DOCKER_FLAGS+=(--gpus all)
+    echo "[appimage-desktop] GPU via legacy runtime"
+  else
+    echo "warning: no CDI spec or nvidia runtime found; running without GPU." >&2
+  fi
+fi
+
+docker rm -f biome-appimage-desktop >/dev/null 2>&1 || true
+
+cat <<EOF
+
+[appimage-desktop] ready ($DISTRO)
+  Browser:  http://localhost:$NOVNC_PORT/
+  Terminal: biome
+  Logs:     out/appimage-test-out/biome.log
+  Ctrl-C to stop.
+
+EOF
+
+exec docker run "${DOCKER_FLAGS[@]}" "$IMAGE_TAG"

--- a/scripts/appimage-post-make.mjs
+++ b/scripts/appimage-post-make.mjs
@@ -1,0 +1,337 @@
+#!/usr/bin/env node
+
+/**
+ * Forge `postMake` post-processor for the Linux AppImage artifact.
+ *
+ * Extracts the .AppImage, runs linuxdeploy + plugin-gtk, bundles the
+ * transitive dependency closure + NSS dlopen plugins, installs the Zig
+ * toolchain + AppRun wrapper, and re-squashes with appimagetool.
+ *
+ * Assets (linuxdeploy, appimagetool, zig) must already exist under
+ * build/appimage/; run scripts/appimage-prepare-assets.mjs to populate.
+ */
+
+import {
+  chmodSync,
+  cpSync,
+  existsSync,
+  mkdirSync,
+  readFileSync,
+  readdirSync,
+  renameSync,
+  rmSync,
+  statSync,
+  symlinkSync,
+  writeFileSync
+} from 'node:fs'
+import { spawnSync } from 'node:child_process'
+import { dirname, resolve } from 'node:path'
+import { fileURLToPath } from 'node:url'
+import { tmpdir } from 'node:os'
+
+const __dirname = dirname(fileURLToPath(import.meta.url))
+const root = resolve(__dirname, '..')
+
+const APPIMAGE_DIR = resolve(root, 'build', 'appimage')
+const CACHE_DIR = resolve(APPIMAGE_DIR, '.cache')
+const TOOLCHAIN_DIR = resolve(APPIMAGE_DIR, 'toolchain')
+
+const LINUXDEPLOY = resolve(CACHE_DIR, 'linuxdeploy-x86_64.AppImage')
+const LINUXDEPLOY_PLUGIN_GTK = resolve(CACHE_DIR, 'linuxdeploy-plugin-gtk.sh')
+const APPIMAGETOOL = resolve(CACHE_DIR, 'appimagetool-x86_64.AppImage')
+const ZIG_DIR = resolve(TOOLCHAIN_DIR, 'zig')
+
+const APPRUN_TEMPLATE = resolve(APPIMAGE_DIR, 'AppRun')
+const CC_SHIM_TEMPLATE = resolve(APPIMAGE_DIR, 'cc-shim')
+
+/** Forge hook entry point. */
+export default async function postMake(makeResults) {
+  if (process.platform !== 'linux') return makeResults
+
+  for (const result of makeResults) {
+    if (result.platform !== 'linux') continue
+    for (const artifactPath of result.artifacts.filter((a) => a.endsWith('.AppImage'))) {
+      console.log(`\n[appimage-post-make] processing ${artifactPath}`)
+      rebuildAppImage(artifactPath)
+    }
+  }
+
+  return makeResults
+}
+
+function rebuildAppImage(artifactPath) {
+  assertTools()
+
+  const workDir = resolve(tmpdir(), `biome-appimage-${process.pid}-${Date.now()}`)
+  mkdirSync(workDir, { recursive: true })
+  try {
+    const appDir = extractAppImage(artifactPath, workDir)
+    runLinuxdeploy(appDir)
+    bundleDependencyClosure(appDir)
+    bundleDlopenPlugins(appDir)
+    installToolchain(appDir)
+    installAppRun(appDir)
+    fixupDesktopEntry(appDir)
+    rebuildWithAppimagetool(appDir, artifactPath)
+    console.log(`[appimage-post-make] rebuilt ${artifactPath}`)
+  } finally {
+    rmSync(workDir, { recursive: true, force: true })
+  }
+}
+
+function assertTools() {
+  const missing = []
+  for (const [label, path] of [
+    ['linuxdeploy', LINUXDEPLOY],
+    ['linuxdeploy-plugin-gtk', LINUXDEPLOY_PLUGIN_GTK],
+    ['appimagetool', APPIMAGETOOL],
+    ['zig toolchain dir', ZIG_DIR],
+    ['AppRun template', APPRUN_TEMPLATE],
+    ['cc-shim template', CC_SHIM_TEMPLATE]
+  ]) {
+    if (!existsSync(path)) missing.push(`${label} (${path})`)
+  }
+  if (missing.length) {
+    throw new Error(
+      `[appimage-post-make] missing assets:\n  - ${missing.join('\n  - ')}\n` +
+        `Run: node scripts/appimage-prepare-assets.mjs`
+    )
+  }
+}
+
+function extractAppImage(artifactPath, workDir) {
+  console.log('[appimage-post-make] extracting AppImage...')
+  run(artifactPath, ['--appimage-extract'], { cwd: workDir })
+  return resolve(workDir, 'squashfs-root')
+}
+
+function runLinuxdeploy(appDir) {
+  console.log('[appimage-post-make] running linuxdeploy...')
+
+  const executable = findElectronExecutable(appDir)
+
+  run(
+    LINUXDEPLOY,
+    ['--appdir', appDir, '--executable', executable, '--plugin', 'gtk', '--deploy-deps-only', executable],
+    {
+      env: {
+        ...process.env,
+        APPIMAGE_EXTRACT_AND_RUN: '1',
+        LINUXDEPLOY_PLUGIN_GTK: LINUXDEPLOY_PLUGIN_GTK,
+        DEPLOY_GTK_VERSION: '3',
+        NO_APPIMAGE: '1'
+      }
+    }
+  )
+}
+
+function findElectronExecutable(appDir) {
+  for (const name of ['biome', 'Biome']) {
+    const candidate = resolve(appDir, 'usr', 'bin', name)
+    if (existsSync(candidate)) return candidate
+  }
+
+  // Fallback: first executable in usr/bin.
+  const binDir = resolve(appDir, 'usr', 'bin')
+  if (existsSync(binDir)) {
+    for (const entry of readdirSync(binDir)) {
+      const full = resolve(binDir, entry)
+      const st = statSync(full, { throwIfNoEntry: false })
+      if (st?.isFile() && (st.mode & 0o111) !== 0) return full
+    }
+  }
+
+  throw new Error(`[appimage-post-make] no executable found under ${appDir}/usr/bin`)
+}
+
+/**
+ * linuxdeploy's excludelist skips libs it assumes the host provides (libX11,
+ * libxcb, libz, etc.). That fails on NixOS and minimal containers. Walk the
+ * full dependency closure and copy anything that resolves outside the AppDir.
+ * Glibc/kernel-provided libs are excluded (must match the host).
+ */
+function bundleDependencyClosure(appDir) {
+  console.log('[appimage-post-make] bundling transitive dependency closure...')
+
+  const libDir = resolve(appDir, 'usr', 'lib')
+  const NEVER_BUNDLE = new Set([
+    'ld-linux-x86-64.so.2',
+    'linux-vdso.so.1',
+    'libc.so.6',
+    'libm.so.6',
+    'libpthread.so.0',
+    'libdl.so.2',
+    'librt.so.1',
+    'libresolv.so.2',
+    'libnsl.so.1',
+    'libutil.so.1',
+    'libcrypt.so.1'
+  ])
+
+  const bundled = new Set(readdirSync(libDir).filter((n) => n.includes('.so')))
+  const visited = new Set()
+  const queue = [resolve(appDir, 'usr', 'lib', 'biome', 'biome')]
+  for (const name of bundled) queue.push(resolve(libDir, name))
+
+  const ldLibPath = `${libDir}:${resolve(appDir, 'usr', 'lib', 'biome')}`
+  let addedCount = 0
+
+  while (queue.length) {
+    const file = queue.shift()
+    if (visited.has(file)) continue
+    visited.add(file)
+
+    const result = spawnSync('ldd', [file], {
+      encoding: 'utf-8',
+      env: { ...process.env, LD_LIBRARY_PATH: ldLibPath }
+    })
+    if (result.status !== 0) continue
+
+    for (const line of result.stdout.split('\n')) {
+      const match = line.match(/^\s*(\S+)\s+=>\s+(\S+)/)
+      if (!match) continue
+      const [, soname, resolvedPath] = match
+
+      if (NEVER_BUNDLE.has(soname)) continue
+      if (bundled.has(soname)) continue
+      if (resolvedPath === 'not' || !resolvedPath.startsWith('/')) continue
+      if (resolvedPath.startsWith(appDir)) continue
+
+      const dest = resolve(libDir, soname)
+      try {
+        cpSync(resolvedPath, dest, { dereference: true })
+      } catch (err) {
+        console.warn(`  [closure] failed to copy ${resolvedPath}: ${err.message}`)
+        continue
+      }
+      spawnSync('patchelf', ['--set-rpath', '$ORIGIN', dest], { stdio: 'ignore' })
+      bundled.add(soname)
+      queue.push(dest)
+      addedCount++
+    }
+  }
+
+  console.log(`[appimage-post-make] bundled ${addedCount} additional libs`)
+}
+
+/**
+ * Bundle dlopen-only plugins that ldd can't see. Currently: NSS security
+ * plugins (libsoftokn3, libfreebl3, etc.) required by Chromium for
+ * cert/key storage.
+ */
+function bundleDlopenPlugins(appDir) {
+  const libDir = resolve(appDir, 'usr', 'lib')
+  const NSS_DIRS = ['/usr/lib/x86_64-linux-gnu/nss', '/usr/lib64/nss']
+
+  let count = 0
+  for (const src of NSS_DIRS) {
+    if (!existsSync(src)) continue
+    for (const entry of readdirSync(src)) {
+      if (!entry.includes('.so')) continue
+      const dst = resolve(libDir, entry)
+      if (existsSync(dst)) continue
+      try {
+        cpSync(resolve(src, entry), dst, { dereference: true })
+      } catch {
+        continue
+      }
+      spawnSync('patchelf', ['--set-rpath', '$ORIGIN', dst], { stdio: 'ignore' })
+      count++
+    }
+  }
+
+  if (count > 0) {
+    console.log(`[appimage-post-make] bundled ${count} NSS dlopen plugins`)
+  }
+}
+
+function installToolchain(appDir) {
+  console.log('[appimage-post-make] installing zig toolchain + cc shims...')
+
+  const toolchainRoot = resolve(appDir, 'toolchain')
+  rmSync(toolchainRoot, { recursive: true, force: true })
+  mkdirSync(toolchainRoot, { recursive: true })
+
+  cpSync(ZIG_DIR, resolve(toolchainRoot, 'zig'), { recursive: true })
+  chmodSync(resolve(toolchainRoot, 'zig', 'zig'), 0o755)
+
+  const shimDir = resolve(toolchainRoot, 'shim')
+  mkdirSync(shimDir, { recursive: true })
+  const ccShim = resolve(shimDir, 'cc')
+  cpSync(CC_SHIM_TEMPLATE, ccShim)
+  chmodSync(ccShim, 0o755)
+
+  for (const alias of ['gcc', 'clang', 'c++', 'g++', 'clang++', 'cxx']) {
+    const target = resolve(shimDir, alias)
+    rmSync(target, { force: true })
+    symlinkSync('cc', target)
+  }
+}
+
+function installAppRun(appDir) {
+  console.log('[appimage-post-make] swapping AppRun...')
+  const apprun = resolve(appDir, 'AppRun')
+  rmSync(apprun, { force: true })
+  cpSync(APPRUN_TEMPLATE, apprun)
+  chmodSync(apprun, 0o755)
+}
+
+function fixupDesktopEntry(appDir) {
+  const entries = readdirSync(appDir)
+  const desktopName = entries.find((e) => e.endsWith('.desktop'))
+  if (!desktopName) {
+    throw new Error(`[appimage-post-make] no .desktop file at ${appDir} root`)
+  }
+
+  const desktopPath = resolve(appDir, desktopName)
+  const lines = readFileSync(desktopPath, 'utf-8').split('\n')
+
+  const hasKey = (key) => lines.some((l) => l.startsWith(`${key}=`))
+  const insertions = []
+  if (!hasKey('Categories')) insertions.push('Categories=Game;')
+  if (!hasKey('Icon')) insertions.push('Icon=biome')
+
+  if (insertions.length) {
+    const out = []
+    let inserted = false
+    for (const line of lines) {
+      if (!inserted && line.startsWith('X-AppImage-')) {
+        out.push(...insertions)
+        inserted = true
+      }
+      out.push(line)
+    }
+    if (!inserted) out.push(...insertions)
+    writeFileSync(desktopPath, out.join('\n'))
+    console.log(`[appimage-post-make] added to ${desktopName}: ${insertions.join(' ')}`)
+  }
+
+  const iconSource = resolve(root, 'app-icon.png')
+  if (existsSync(iconSource)) {
+    cpSync(iconSource, resolve(appDir, 'biome.png'))
+  }
+}
+
+function rebuildWithAppimagetool(appDir, outputPath) {
+  console.log('[appimage-post-make] re-squashing with appimagetool...')
+
+  const tmpOut = `${outputPath}.rebuilt`
+  rmSync(tmpOut, { force: true })
+
+  run(APPIMAGETOOL, [appDir, tmpOut], {
+    env: { ...process.env, APPIMAGE_EXTRACT_AND_RUN: '1', ARCH: 'x86_64' }
+  })
+
+  rmSync(outputPath, { force: true })
+  renameSync(tmpOut, outputPath)
+  chmodSync(outputPath, 0o755)
+}
+
+function run(cmd, args, options = {}) {
+  const result = spawnSync(cmd, args, { stdio: 'inherit', ...options })
+  if (result.status !== 0) {
+    throw new Error(
+      `Command failed (exit ${result.status ?? 'null'}): ${cmd} ${args.map((a) => JSON.stringify(a)).join(' ')}`
+    )
+  }
+}

--- a/scripts/appimage-prepare-assets.mjs
+++ b/scripts/appimage-prepare-assets.mjs
@@ -1,0 +1,203 @@
+#!/usr/bin/env node
+
+/**
+ * Downloads build-time assets needed for the AppImage post-processing step:
+ *
+ *   - linuxdeploy (ELF dep walker + AppImage assembly)
+ *   - linuxdeploy-plugin-gtk (GTK3 schemas / pixbuf loaders / GIO modules)
+ *   - appimagetool (re-squash modified AppDir into a final .AppImage)
+ *   - zig toolchain (shipped inside the AppImage; provides `cc` for Triton)
+ *
+ * Idempotent: skips items that already exist in the cache. Safe to run
+ * from `forge.config.ts` hooks.generateAssets on every build.
+ *
+ * Only runs on Linux x86_64 — other targets return early.
+ */
+
+import { createHash } from 'node:crypto'
+import {
+  chmodSync,
+  createReadStream,
+  createWriteStream,
+  existsSync,
+  mkdirSync,
+  readdirSync,
+  renameSync,
+  rmSync
+} from 'node:fs'
+import { pipeline } from 'node:stream/promises'
+import { dirname, resolve } from 'node:path'
+import { fileURLToPath } from 'node:url'
+import { Readable } from 'node:stream'
+import { spawnSync } from 'node:child_process'
+
+const __dirname = dirname(fileURLToPath(import.meta.url))
+const root = resolve(__dirname, '..')
+
+const APPIMAGE_DIR = resolve(root, 'build', 'appimage')
+const CACHE_DIR = resolve(APPIMAGE_DIR, '.cache')
+const TOOLCHAIN_DIR = resolve(APPIMAGE_DIR, 'toolchain')
+
+// --- Pinned versions ------------------------------------------------------
+// Every URL below points at an immutable reference (tagged release or commit
+// SHA) rather than a moving `continuous`/`master` pointer. Bumping a version
+// means updating both the URL and the matching SHA256 in lock-step: null the
+// hash, re-run this script, paste the logged value back in. A null hash
+// skips verification in dev mode and hard-errors on CI.
+
+// Zig 0.16 changed the tarball naming convention from
+// `zig-linux-x86_64-<ver>` to `zig-x86_64-linux-<ver>` — keep the basename
+// var in sync with the archive's top-level dir for the extractor.
+const ZIG_VERSION = '0.16.0'
+const ZIG_TARBALL_BASENAME = `zig-x86_64-linux-${ZIG_VERSION}`
+const ZIG_URL = `https://ziglang.org/download/${ZIG_VERSION}/${ZIG_TARBALL_BASENAME}.tar.xz`
+const ZIG_SHA256 = '70e49664a74374b48b51e6f3fdfbf437f6395d42509050588bd49abe52ba3d00'
+
+// linuxdeploy tags alpha-YYYYMMDD-N snapshots; pin to one rather than
+// `continuous` so sha256 stays stable.
+const LINUXDEPLOY_VERSION = '1-alpha-20251107-1'
+const LINUXDEPLOY_URL = `https://github.com/linuxdeploy/linuxdeploy/releases/download/${LINUXDEPLOY_VERSION}/linuxdeploy-x86_64.AppImage`
+const LINUXDEPLOY_SHA256 = 'c20cd71e3a4e3b80c3483cef793cda3f4e990aca14014d23c544ca3ce1270b4d'
+
+// linuxdeploy-plugin-gtk has no releases — pin by commit SHA.
+const LINUXDEPLOY_PLUGIN_GTK_COMMIT = '3b67a1d1c1b0c8268f57f2bce40fe2d33d409cea'
+const LINUXDEPLOY_PLUGIN_GTK_URL = `https://raw.githubusercontent.com/linuxdeploy/linuxdeploy-plugin-gtk/${LINUXDEPLOY_PLUGIN_GTK_COMMIT}/linuxdeploy-plugin-gtk.sh`
+const LINUXDEPLOY_PLUGIN_GTK_SHA256 = 'b0f4cbc684a0103a9651f0955b635eaea0096b3a66c0f5a2c2aa337960375171'
+
+// AppImage/appimagetool (modern repo; libfuse3-free static runtime).
+const APPIMAGETOOL_VERSION = '1.9.1'
+const APPIMAGETOOL_URL = `https://github.com/AppImage/appimagetool/releases/download/${APPIMAGETOOL_VERSION}/appimagetool-x86_64.AppImage`
+const APPIMAGETOOL_SHA256 = 'ed4ce84f0d9caff66f50bcca6ff6f35aae54ce8135408b3fa33abfc3cb384eb0'
+
+// --- Helpers --------------------------------------------------------------
+
+function shouldRun() {
+  if (process.platform !== 'linux') return false
+  if (process.arch !== 'x64') {
+    console.warn(`[appimage-prepare-assets] skipping: unsupported arch ${process.arch} (only x64 is supported)`)
+    return false
+  }
+  return true
+}
+
+async function sha256File(filePath) {
+  const hash = createHash('sha256')
+  await pipeline(createReadStream(filePath), hash)
+  return hash.digest('hex')
+}
+
+async function download(url, destPath) {
+  console.log(`[appimage-prepare-assets] downloading ${url}`)
+  const response = await fetch(url)
+  if (!response.ok || !response.body) {
+    throw new Error(`Download failed: HTTP ${response.status} ${response.statusText} (${url})`)
+  }
+
+  mkdirSync(dirname(destPath), { recursive: true })
+  const tmpPath = `${destPath}.partial`
+  await pipeline(Readable.fromWeb(response.body), createWriteStream(tmpPath))
+  renameSync(tmpPath, destPath)
+}
+
+async function ensureDownloaded(name, url, destPath, expectedSha256) {
+  if (existsSync(destPath)) {
+    if (expectedSha256) {
+      const actual = await sha256File(destPath)
+      if (actual !== expectedSha256) {
+        console.warn(`[appimage-prepare-assets] ${name}: cached checksum mismatch, re-downloading`)
+      } else {
+        return
+      }
+    } else {
+      return
+    }
+  }
+
+  await download(url, destPath)
+  const actual = await sha256File(destPath)
+  console.log(`[appimage-prepare-assets] ${name} sha256: ${actual}`)
+
+  if (expectedSha256) {
+    if (actual !== expectedSha256) {
+      throw new Error(`${name}: sha256 mismatch\n  expected ${expectedSha256}\n  got      ${actual}`)
+    }
+  } else if (process.env.CI) {
+    // On CI, require pinned hashes — otherwise supply-chain attacks slip in.
+    throw new Error(`${name}: no sha256 pinned (got ${actual}). Pin it in scripts/appimage-prepare-assets.mjs.`)
+  } else {
+    console.warn(`[appimage-prepare-assets] ${name}: no sha256 pinned — skipping verification (dev only)`)
+  }
+}
+
+async function extractZigToDir(archivePath, targetDir, expectedChildPrefix) {
+  // If the zig binary is already in place, nothing to do.
+  if (existsSync(resolve(targetDir, 'zig'))) return
+
+  const tmpDir = `${targetDir}.extract`
+  rmSync(tmpDir, { recursive: true, force: true })
+  mkdirSync(tmpDir, { recursive: true })
+
+  // System `tar` handles xz natively across platforms; the npm `tar` package
+  // is gzip-only and fails on .tar.xz with TAR_BAD_ARCHIVE.
+  const result = spawnSync('tar', ['-xf', archivePath, '-C', tmpDir], { stdio: 'inherit' })
+  if (result.status !== 0) {
+    throw new Error(`tar -xf ${archivePath} failed with status ${result.status}`)
+  }
+
+  const entries = readdirSync(tmpDir)
+  const extracted = entries.find((e) => e.startsWith(expectedChildPrefix))
+  if (!extracted) {
+    throw new Error(`Extraction failed: no entry starting with "${expectedChildPrefix}" in ${tmpDir}`)
+  }
+
+  rmSync(targetDir, { recursive: true, force: true })
+  renameSync(resolve(tmpDir, extracted), targetDir)
+  rmSync(tmpDir, { recursive: true, force: true })
+}
+
+// --- Main -----------------------------------------------------------------
+
+async function main() {
+  if (!shouldRun()) return
+
+  mkdirSync(CACHE_DIR, { recursive: true })
+  mkdirSync(TOOLCHAIN_DIR, { recursive: true })
+
+  // 1. linuxdeploy
+  const linuxdeployPath = resolve(CACHE_DIR, 'linuxdeploy-x86_64.AppImage')
+  await ensureDownloaded('linuxdeploy', LINUXDEPLOY_URL, linuxdeployPath, LINUXDEPLOY_SHA256)
+  chmodSync(linuxdeployPath, 0o755)
+
+  // 2. linuxdeploy-plugin-gtk (shell script, not an AppImage)
+  const pluginGtkPath = resolve(CACHE_DIR, 'linuxdeploy-plugin-gtk.sh')
+  await ensureDownloaded(
+    'linuxdeploy-plugin-gtk',
+    LINUXDEPLOY_PLUGIN_GTK_URL,
+    pluginGtkPath,
+    LINUXDEPLOY_PLUGIN_GTK_SHA256
+  )
+  chmodSync(pluginGtkPath, 0o755)
+
+  // 3. appimagetool
+  const appimagetoolPath = resolve(CACHE_DIR, 'appimagetool-x86_64.AppImage')
+  await ensureDownloaded('appimagetool', APPIMAGETOOL_URL, appimagetoolPath, APPIMAGETOOL_SHA256)
+  chmodSync(appimagetoolPath, 0o755)
+
+  // 4. Zig toolchain
+  const zigArchivePath = resolve(CACHE_DIR, `${ZIG_TARBALL_BASENAME}.tar.xz`)
+  await ensureDownloaded('zig', ZIG_URL, zigArchivePath, ZIG_SHA256)
+
+  const zigFinalDir = resolve(TOOLCHAIN_DIR, 'zig')
+  await extractZigToDir(zigArchivePath, zigFinalDir, ZIG_TARBALL_BASENAME)
+
+  console.log('[appimage-prepare-assets] assets ready:')
+  console.log(`  linuxdeploy            -> ${linuxdeployPath}`)
+  console.log(`  linuxdeploy-plugin-gtk -> ${pluginGtkPath}`)
+  console.log(`  appimagetool           -> ${appimagetoolPath}`)
+  console.log(`  zig                    -> ${zigFinalDir}/zig`)
+}
+
+main().catch((err) => {
+  console.error(err)
+  process.exit(1)
+})


### PR DESCRIPTION
Fixes #92. Fixes #89.

Overhauls the Linux AppImage to be a self-contained bundle that works across distributions without requiring users to have GTK dev libraries, a C toolchain, or a correctly-configured OpenSSL.

The previous AppImage was a thin wrapper that relied on the host system for ~130 shared libraries, a working OpenSSL config, and `gcc` for Triton's runtime CUDA JIT compilation.

## What changed

### AppImage post-processing pipeline (`scripts/appimage-post-make.mjs`)

Forge's `postMake` hook now runs a multi-step post-processor on the produced `.AppImage`:

1. **linuxdeploy + plugin-gtk** bundles GTK3/X11/GLib shared libraries into the AppDir with rpath patching.
2. **Transitive dependency closure** - a second `ldd`-based pass catches libs that linuxdeploy's excludelist skips (libX11, libxcb, libz, libfreetype, etc.). Without this, the AppImage fails on NixOS and other non-FHS distros.
3. **NSS dlopen plugins** (libsoftokn3, libfreebl3, etc.) are copied explicitly - they're loaded at runtime via `dlopen`, invisible to `ldd`, and Chromium crashes without them.
4. **Zig 0.16 toolchain** is bundled under `AppDir/toolchain/` with `cc`/`gcc`/`clang` shim symlinks. Triton JIT-compiles CUDA launcher stubs with `cc` at runtime; most user systems don't have a C compiler. The shim rewrites `-l:libfoo.so.N` → `-lfoo` to work around zig's lld not supporting the GNU `-l:` extension.
5. **AppRun wrapper** (`build/appimage/AppRun`) replaces the default symlink with a shell script that sets `LD_LIBRARY_PATH` for bundled libs, `OPENSSL_CONF=/dev/null` (fixes #92), detects the host's `libcuda.so` path for Triton, exposes the Zig toolchain on `$PATH`, and sources linuxdeploy-plugin-gtk's GTK module/schema hooks.
6. **Desktop entry fixup** - injects `Categories=Game;` and `Icon=biome` (appimagetool requires both).

All build tools (linuxdeploy, appimagetool, zig) are downloaded by `scripts/appimage-prepare-assets.mjs` with pinned SHA256 hashes (CI refuses to proceed without them). Versions are pinned to immutable references (tagged releases / commit SHAs), not moving `continuous` tags.

### Electron runtime changes

- **`electron/lib/uv.ts`**: Sets `OPENSSL_CONF=/dev/null` on Linux in `getUvEnvVars()` as belt-and-suspenders behind the AppRun wrapper. Adds `getBundledPythonIncludeDir()` to locate the uv-managed Python's include directory.
- **`electron/ipc/server.ts`**: Threads `C_INCLUDE_PATH` into the server process env, pointing at the bundled Python headers so Triton's JIT can find `Python.h`. Generalises the `shell.nix` workaround for NixOS.

### Build environment sharing

`build/appimage/setup-build-env.sh` is the single source of truth for the Linux build environment (Node.js 20 via NodeSource + apt deps from `apt-deps.txt`). It accepts stage arguments (`bootstrap`, `node`, `deps`) so the Dockerfile can split it into cacheable layers while CI runs it as one shot. Both CI workflows and the Docker build image use this same script - no independent `apt-get` or `actions/setup-node` on the Linux path.

### Local Docker build (`scripts/appimage-docker-build.sh`)

Builds the AppImage inside an ubuntu-22.04 Docker container that uses the same `setup-build-env.sh` script. Output lands at `out/make/AppImage/x64/`. Useful for producing a release-quality AppImage from any host OS (including NixOS/macOS) without polluting the host.

### CI workflows

Both `ci.yml` and `release.yml` now run `sudo ./build/appimage/setup-build-env.sh` directly on the ubuntu-22.04 runner for Linux builds (no Docker overhead in CI). Windows builds still use `actions/setup-node` natively.

### Multi-distro test infrastructure

`scripts/appimage-docker-desktop.sh` spins up a containerised Wayland desktop (sway + wayvnc + noVNC) accessible via browser at `http://localhost:6080/`. Parameterised by distro:

```bash
./scripts/appimage-docker-desktop.sh                  # Ubuntu 24.04
./scripts/appimage-docker-desktop.sh --distro fedora  # Fedora 41
./scripts/appimage-docker-desktop.sh --distro arch    # Arch Linux
```

Each provides a real Wayland session with GPU passthrough (CDI on NixOS, legacy nvidia runtime elsewhere). A `biome` helper command inside the container launches the AppImage with the right flags and tees output to `out/appimage-test-out/biome.log` on the host.

## AppImage size

~225 MB (up from ~100 MB), broken down as:
- +15–20 MB: GTK/X11 shared libraries (linuxdeploy)
- +18 MB: transitive closure libs (libX11, libxcb, libz, etc.)
- +50–65 MB: Zig 0.16 toolchain
- Remainder: NSS plugins, icons, metadata overhead

## Test results

- **Ubuntu 24.04** (Docker desktop): AppImage launches, engine starts, Triton JIT fires and compiles via bundled zig-cc.
- **Fedora 41** (Docker desktop): AppImage launches.
- **NixOS** (via `appimage-run`): Full launch, UI renders, engine detects GPU and syncs dependencies.
- **NixOS** (direct): Crashes at Chromium DBus init - expected; `appimage-run` is required on NixOS.
