### PR TITLE
Block Program Files as install dir

### DIFF
--- a/build/installer.nsh
+++ b/build/installer.nsh
@@ -1,3 +1,17 @@
+Function .onVerifyInstDir
+  # Reject installs under Program Files — the app writes to $INSTDIR at runtime
+  # (uv, world_engine/, HF cache) and those paths require admin rights to write.
+  StrLen $R0 "$PROGRAMFILES"
+  StrCpy $R1 "$INSTDIR" $R0
+  StrCmp $R1 "$PROGRAMFILES" 0 +2
+    Abort
+
+  StrLen $R0 "$PROGRAMFILES64"
+  StrCpy $R1 "$INSTDIR" $R0
+  StrCmp $R1 "$PROGRAMFILES64" 0 +2
+    Abort
+FunctionEnd
+
 !macro customRemoveFiles
   StrCpy $R1 "$PLUGINSDIR\biome-hf-cache-backup"
 

--- a/build/installer.nsh
+++ b/build/installer.nsh
@@ -1,3 +1,7 @@
+# Override the directory page's top text to warn about Program Files.
+# This is prepended before MUI2 is included, so the define is picked up when MUI_PAGE_DIRECTORY runs.
+!define MUI_DIRECTORYPAGE_TEXT_TOP "Setup will install $(^NameDA) in the following folder.$\r$\n$\r$\nTo install in a different folder, click Browse and select another folder.$\r$\n$\r$\nNote: Biome cannot be installed under Program Files - Windows prevents applications from writing files to their own installation directory within Program Files. If the button is greyed out, try another directory."
+
 Function .onVerifyInstDir
   # Reject installs under Program Files — the app writes to $INSTDIR at runtime
   # (uv, world_engine/, HF cache) and those paths require admin rights to write.

--- a/forge.config.ts
+++ b/forge.config.ts
@@ -29,6 +29,7 @@ const config: ForgeConfig = {
         },
         nsis: {
           oneClick: false,
+          perMachine: false,
           allowToChangeInstallationDirectory: true,
           uninstallDisplayName: 'Biome',
           license: 'licensing/EULA.txt',


### PR DESCRIPTION
Fixes #108.

Does not allow Program Files to be used as an install directory, and prevents it from being used as a default. Dependent on being tested on Windows.