### PR TITLE
Use mirrors for Zig

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -27,6 +27,7 @@
         "@electron-forge/plugin-vite": "^7",
         "@eslint/js": "^10.0.1",
         "@felixrieseberg/electron-forge-maker-nsis": "^7.2.0",
+        "@kaito-tokyo/minisign-verify": "^0.1.4",
         "@reforged/maker-appimage": "^5.2.0",
         "@types/adm-zip": "^0.5",
         "@types/node": "^22",
@@ -1766,6 +1767,19 @@
       "dependencies": {
         "@jridgewell/resolve-uri": "^3.1.0",
         "@jridgewell/sourcemap-codec": "^1.4.14"
+      }
+    },
+    "node_modules/@kaito-tokyo/minisign-verify": {
+      "version": "0.1.4",
+      "resolved": "https://registry.npmjs.org/@kaito-tokyo/minisign-verify/-/minisign-verify-0.1.4.tgz",
+      "integrity": "sha512-gSQ4m0j2DI7QE+X64JnQ74hUMa5BUBG7gEdSLuKJl7194zuEjhPGxKDnnConmTKkv5fGqIQzBc3RdoUuHNfyaQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "minisign-verify": "verify-js/minisign-verify-cli.mjs"
+      },
+      "engines": {
+        "node": ">=24.0.0"
       }
     },
     "node_modules/@listr2/prompt-adapter-inquirer": {

--- a/package.json
+++ b/package.json
@@ -32,6 +32,7 @@
     "@electron-forge/plugin-vite": "^7",
     "@eslint/js": "^10.0.1",
     "@felixrieseberg/electron-forge-maker-nsis": "^7.2.0",
+    "@kaito-tokyo/minisign-verify": "^0.1.4",
     "@reforged/maker-appimage": "^5.2.0",
     "@types/adm-zip": "^0.5",
     "@types/node": "^22",

--- a/scripts/appimage-prepare-assets.mjs
+++ b/scripts/appimage-prepare-assets.mjs
@@ -31,6 +31,8 @@ import { fileURLToPath } from 'node:url'
 import { Readable } from 'node:stream'
 import { spawnSync } from 'node:child_process'
 
+import { MinisignVerifier } from '@kaito-tokyo/minisign-verify'
+
 const __dirname = dirname(fileURLToPath(import.meta.url))
 const root = resolve(__dirname, '..')
 
@@ -39,19 +41,36 @@ const CACHE_DIR = resolve(APPIMAGE_DIR, '.cache')
 const TOOLCHAIN_DIR = resolve(APPIMAGE_DIR, 'toolchain')
 
 // --- Pinned versions ------------------------------------------------------
-// Every URL below points at an immutable reference (tagged release or commit
-// SHA) rather than a moving `continuous`/`master` pointer. Bumping a version
-// means updating both the URL and the matching SHA256 in lock-step: null the
-// hash, re-run this script, paste the logged value back in. A null hash
-// skips verification in dev mode and hard-errors on CI.
+// GitHub-hosted assets (linuxdeploy / appimagetool / plugin-gtk) are pinned
+// by URL + SHA256 in lock-step. Bumping one means: null the hash, re-run
+// this script, paste the logged value back in. A null hash skips
+// verification in dev mode and hard-errors on CI.
+//
+// Zig is different — ziglang.org is a single host that explicitly asks CI
+// not to download from it, so we fetch from the community mirror list and
+// verify each tarball against the ZSF minisign public key (see
+// https://ziglang.org/download/community-mirrors/). Bumping Zig only
+// requires changing ZIG_VERSION; the signature is the integrity gate.
 
 // Zig 0.16 changed the tarball naming convention from
 // `zig-linux-x86_64-<ver>` to `zig-x86_64-linux-<ver>` — keep the basename
 // var in sync with the archive's top-level dir for the extractor.
 const ZIG_VERSION = '0.16.0'
 const ZIG_TARBALL_BASENAME = `zig-x86_64-linux-${ZIG_VERSION}`
-const ZIG_URL = `https://ziglang.org/download/${ZIG_VERSION}/${ZIG_TARBALL_BASENAME}.tar.xz`
-const ZIG_SHA256 = '70e49664a74374b48b51e6f3fdfbf437f6395d42509050588bd49abe52ba3d00'
+
+// ZSF minisign public key, from https://ziglang.org/download.
+const ZIG_MINISIGN_PUBKEY = 'RWSGOq2NVecA2UPNdBUZykf1CCb147pkmdtYxgb3Ti+JO/wCYvhbAb/U'
+const ZIG_MIRROR_LIST_URL = 'https://ziglang.org/download/community-mirrors.txt'
+// Used only if the live mirror list fetch fails. Trimmed snapshot of the
+// upstream list — only needs updating if the upstream list churns
+// significantly.
+const ZIG_FALLBACK_MIRRORS = [
+  'https://pkg.machengine.org/zig',
+  'https://zigmirror.hryx.net/zig',
+  'https://ziglang.freetls.fastly.net',
+  'https://zig.linus.dev/zig',
+  'https://zig.squirl.dev'
+]
 
 // linuxdeploy tags alpha-YYYYMMDD-N snapshots; pin to one rather than
 // `continuous` so sha256 stays stable.
@@ -155,6 +174,81 @@ async function extractZigToDir(archivePath, targetDir, expectedChildPrefix) {
   rmSync(tmpDir, { recursive: true, force: true })
 }
 
+// --- Zig mirror download --------------------------------------------------
+
+async function fetchZigMirrors() {
+  try {
+    const response = await fetch(ZIG_MIRROR_LIST_URL)
+    if (!response.ok) {
+      throw new Error(`HTTP ${response.status} ${response.statusText}`)
+    }
+    const list = (await response.text()).split('\n').filter((s) => s.length > 0)
+    if (list.length === 0) {
+      throw new Error('mirror list is empty')
+    }
+    return list
+  } catch (err) {
+    console.warn(`[appimage-prepare-assets] zig: mirror list fetch failed (${err.message}); using hardcoded fallback`)
+    return [...ZIG_FALLBACK_MIRRORS]
+  }
+}
+
+function shuffle(arr) {
+  const out = [...arr]
+  for (let i = out.length - 1; i > 0; i--) {
+    const j = Math.floor(Math.random() * (i + 1))
+    ;[out[i], out[j]] = [out[j], out[i]]
+  }
+  return out
+}
+
+async function verifyZigArtifact(verifier, tarballPath, sigPath, expectedFilename) {
+  const result = await verifier.verifyFilepath(tarballPath, sigPath)
+  if (!result.ok) return false
+  // Bind the signature to the requested filename so a malicious mirror
+  // can't pass off one signed tarball as another.
+  const match = /^timestamp:\d+\s+file:([^\s]+)\s+hashed$/.exec(result.trustedComment)
+  return match !== null && match[1] === expectedFilename
+}
+
+async function downloadAndVerifyZig(filename, destPath) {
+  const sigPath = `${destPath}.minisig`
+  const verifier = await MinisignVerifier.create(ZIG_MINISIGN_PUBKEY)
+
+  if (existsSync(destPath) && existsSync(sigPath)) {
+    try {
+      if (await verifyZigArtifact(verifier, destPath, sigPath, filename)) {
+        return
+      }
+      console.warn(`[appimage-prepare-assets] zig: cached signature failed re-verification, re-downloading`)
+    } catch {
+      // fall through to redownload
+    }
+  }
+
+  const mirrors = shuffle(await fetchZigMirrors())
+
+  const errors = []
+  for (const mirror of mirrors) {
+    const tarballUrl = `${mirror}/${filename}?source=biome`
+    const sigUrl = `${mirror}/${filename}.minisig?source=biome`
+    console.log(`[appimage-prepare-assets] zig: trying ${mirror}`)
+    try {
+      await download(tarballUrl, destPath)
+      await download(sigUrl, sigPath)
+      if (!(await verifyZigArtifact(verifier, destPath, sigPath, filename))) {
+        throw new Error('signature or filename verification failed')
+      }
+      console.log(`[appimage-prepare-assets] zig: verified from ${mirror}`)
+      return
+    } catch (err) {
+      errors.push(`  ${mirror}: ${err.message}`)
+    }
+  }
+
+  throw new Error(`zig: every mirror failed:\n${errors.join('\n')}`)
+}
+
 // --- Main -----------------------------------------------------------------
 
 async function main() {
@@ -183,9 +277,10 @@ async function main() {
   await ensureDownloaded('appimagetool', APPIMAGETOOL_URL, appimagetoolPath, APPIMAGETOOL_SHA256)
   chmodSync(appimagetoolPath, 0o755)
 
-  // 4. Zig toolchain
-  const zigArchivePath = resolve(CACHE_DIR, `${ZIG_TARBALL_BASENAME}.tar.xz`)
-  await ensureDownloaded('zig', ZIG_URL, zigArchivePath, ZIG_SHA256)
+  // 4. Zig toolchain — fetched from a community mirror with minisign verification.
+  const zigArchiveFilename = `${ZIG_TARBALL_BASENAME}.tar.xz`
+  const zigArchivePath = resolve(CACHE_DIR, zigArchiveFilename)
+  await downloadAndVerifyZig(zigArchiveFilename, zigArchivePath)
 
   const zigFinalDir = resolve(TOOLCHAIN_DIR, 'zig')
   await extractZigToDir(zigArchivePath, zigFinalDir, ZIG_TARBALL_BASENAME)


### PR DESCRIPTION
Zig (understandably) throttles/blocks downloads from CI servers and recommends that you use a list of mirrors instead. This PR does that.