### PR TITLE
Consistent settings behaviour

### DIFF
--- a/electron/ipc/engine.ts
+++ b/electron/ipc/engine.ts
@@ -255,9 +255,19 @@ export function registerEngineIpc(): void {
           })
           dependenciesSynced = true
           diagLog.info('check-engine-status: dependency validation ok')
-        } catch {
+        } catch (err) {
           dependenciesSynced = false
-          diagLog.info('check-engine-status: dependency validation failed')
+          const e = err as { stderr?: Buffer | string; stdout?: Buffer | string; message?: string; code?: number }
+          const stderr = e.stderr?.toString() ?? ''
+          const stdout = e.stdout?.toString() ?? ''
+          diagLog.info('check-engine-status: dependency validation failed', {
+            fields: {
+              exit_code: e.code ?? -1,
+              stderr: stderr.trim() || undefined,
+              stdout: stdout.trim() || undefined,
+              message: !stderr && !stdout ? (e.message ?? '') : undefined
+            }
+          })
         }
       }
     }

--- a/electron/ipc/settings.ts
+++ b/electron/ipc/settings.ts
@@ -168,9 +168,15 @@ export function readSettingsSync(): Settings {
 }
 
 /** Env vars injected into any uv / python subprocess when offline mode is on.
- *  Single source of truth — both engine setup and the server spawn consume this. */
+ *  Single source of truth — both engine setup and the server spawn consume this.
+ *  `UV_NO_SYNC` (implies `--frozen`) skips uv's resolve + sync passes on
+ *  `uv run`; in offline mode any fetch attempt would fail anyway, and the venv
+ *  is presumed correct from the last online sync.  In online mode it's omitted
+ *  so `uv run` continues to auto-install new deps when pyproject changes. */
 export function getOfflineEnv(): Record<string, string> {
-  return readSettingsSync().offline_mode ? { UV_OFFLINE: '1', HF_HUB_OFFLINE: '1', TRANSFORMERS_OFFLINE: '1' } : {}
+  return readSettingsSync().offline_mode
+    ? { UV_OFFLINE: '1', UV_NO_SYNC: '1', HF_HUB_OFFLINE: '1', TRANSFORMERS_OFFLINE: '1' }
+    : {}
 }
 
 export function registerSettingsIpc(): void {

--- a/src/components/settings/EngineTab.tsx
+++ b/src/components/settings/EngineTab.tsx
@@ -48,10 +48,6 @@ export type EngineTabHandle = {
   /** Check whether the current draft is savable. If not, surfaces an error modal
    *  internally and returns false so the parent can abort the save flow. */
   validateBeforeSave: () => boolean
-  /** True when engine-mode / world-model / backend / quantization differ from
-   *  persisted settings — parent uses this (alongside `isStreaming`) to decide
-   *  whether a mid-session restart confirmation modal is needed. */
-  hasChangesRequiringRestart: () => boolean
 }
 
 type EngineTabProps = {
@@ -68,7 +64,6 @@ const EngineTab = forwardRef<EngineTabHandle, EngineTabProps>((props, ref) => {
   const engine = useEngine()
   const checkEngine = engine.check
 
-  const configEngineMode = settings.engine_mode
   const configWorldModel = settings.engine_model
   const configServerUrl = settings.server_url
   const savedCustomModels = useMemo(() => settings.custom_models ?? [], [settings.custom_models])
@@ -138,14 +133,6 @@ const EngineTab = forwardRef<EngineTabHandle, EngineTabProps>((props, ref) => {
           return false
         }
         return true
-      },
-      hasChangesRequiringRestart: () => {
-        const configMode = configEngineMode === ENGINE_MODES.SERVER ? 'server' : 'standalone'
-        if (menuEngineMode !== configMode) return true
-        if (menuWorldModel !== configWorldModel) return true
-        if (menuQuant !== (settings.engine_quant ?? 'none')) return true
-        if (menuEngineBackend !== (settings.engine_backend ?? 'world_engine')) return true
-        return false
       }
     }),
     [
@@ -156,11 +143,7 @@ const EngineTab = forwardRef<EngineTabHandle, EngineTabProps>((props, ref) => {
       menuEngineBackend,
       menuCapInferenceFps,
       serverUrlStatus,
-      configEngineMode,
-      configServerUrl,
-      configWorldModel,
-      settings.engine_quant,
-      settings.engine_backend
+      configServerUrl
     ]
   )
 

--- a/src/components/settings/MenuSettingsView.tsx
+++ b/src/components/settings/MenuSettingsView.tsx
@@ -4,7 +4,8 @@ import type { TranslationKey } from '../../i18n'
 import { VIEW_DESCRIPTION, VIEW_HEADING } from '../../styles'
 import { useSettings } from '../../hooks/settings/settingsContextValue'
 import { useConnection } from '../../context/streaming/connection'
-import { ENGINE_MODES } from '../../types/settings'
+import { ENGINE_MODES, type Settings } from '../../types/settings'
+import { diffRequiresRestartConfirmation } from '../../utils/settingsClassifier'
 import { useVolumeControls } from '../../hooks/audio/useVolumeControls'
 import MenuButton from '../ui/MenuButton'
 import SettingsToggle from '../ui/SettingsToggle'
@@ -62,13 +63,13 @@ const MenuSettingsView = ({ onBack }: MenuSettingsViewProps) => {
     setHasKeybindConflict(hasConflict)
   }, [])
 
-  const applyDraftSettings = useCallback(async () => {
+  const buildPendingSettings = useCallback((): Settings => {
     const engineDraft = engineRef.current?.collectDraft() ?? {}
     const keyboardDraft = keyboardRef.current?.collectDraft() ?? {}
     const gamepadDraft = gamepadRef.current?.collectDraft() ?? {}
     const debugDraft = debugRef.current?.collectDraft() ?? {}
 
-    await saveSettings({
+    return {
       ...settings,
       ...engineDraft,
       ...keyboardDraft,
@@ -77,30 +78,23 @@ const MenuSettingsView = ({ onBack }: MenuSettingsViewProps) => {
       audio: volume.getAudioSettings(),
       offline_mode: menuOfflineMode,
       scene_authoring_enabled: menuSceneAuthoringEnabled
-    })
-  }, [settings, saveSettings, volume, menuSceneAuthoringEnabled, menuOfflineMode])
+    }
+  }, [settings, volume, menuSceneAuthoringEnabled, menuOfflineMode])
+
+  const applyDraftSettings = useCallback(async () => {
+    await saveSettings(buildPendingSettings())
+  }, [saveSettings, buildPendingSettings])
 
   const handleBackClick = useCallback(async () => {
     if (hasKeybindConflict) return
     if (engineRef.current && !engineRef.current.validateBeforeSave()) return
-    const offlineChanged =
-      settings.engine_mode === ENGINE_MODES.STANDALONE && menuOfflineMode !== (settings.offline_mode ?? false)
-    const sceneAuthoringChanged = menuSceneAuthoringEnabled !== (settings.scene_authoring_enabled ?? false)
-    if (isStreaming && (engineRef.current?.hasChangesRequiringRestart() || offlineChanged || sceneAuthoringChanged)) {
+    if (isStreaming && diffRequiresRestartConfirmation(settings, buildPendingSettings())) {
       setShowModeSwitchModal(true)
       return
     }
     await applyDraftSettings()
     onBack()
-  }, [
-    hasKeybindConflict,
-    isStreaming,
-    applyDraftSettings,
-    onBack,
-    settings,
-    menuOfflineMode,
-    menuSceneAuthoringEnabled
-  ])
+  }, [hasKeybindConflict, isStreaming, applyDraftSettings, onBack, settings, buildPendingSettings])
 
   useEffect(() => {
     const handleKeyUp = (e: KeyboardEvent) => {

--- a/src/context/streaming/StreamingContext.tsx
+++ b/src/context/streaming/StreamingContext.tsx
@@ -37,7 +37,7 @@ export const StreamingProvider = ({ children }: { children: ReactNode }) => {
   const { state, states, transitionTo } = usePortal()
   const containerRef = useRef<HTMLDivElement | null>(null)
 
-  const { settings, isStandaloneMode, engineMode } = useSettings()
+  const { settings, isStandaloneMode } = useSettings()
   const {
     status: engineStatus,
     startServer,
@@ -136,8 +136,7 @@ export const StreamingProvider = ({ children }: { children: ReactNode }) => {
   }, [isStandaloneMode, checkEngineStatus])
 
   useEngineRespawn({
-    engineMode,
-    offlineMode: settings.offline_mode ?? false,
+    settings,
     portalState: state,
     mainMenuState: states.MAIN_MENU,
     loadingState: states.LOADING,
@@ -155,7 +154,7 @@ export const StreamingProvider = ({ children }: { children: ReactNode }) => {
     })
   }, [getSeedsDirPath])
 
-  const { selectSeed, lastAppliedModel, resetSession } = useSessionInit({
+  const { selectSeed, lastAppliedSession, resetSession } = useSessionInit({
     portalState: state,
     loadingState: states.LOADING,
     isConnected: wsIsConnected(connectionStatus),
@@ -214,10 +213,8 @@ export const StreamingProvider = ({ children }: { children: ReactNode }) => {
   useStreamingLifecycle({
     portalState: state,
     connectionStatus,
-    engineModel: settings?.engine_model,
-    engineQuant: settings.engine_quant,
-    sceneAuthoringEnabled: settings.scene_authoring_enabled,
-    lastAppliedModel,
+    settings,
+    lastAppliedSession,
     engineError,
     hasReceivedFrame,
     // Init is considered complete once applyInitResponse has set the
@@ -229,7 +226,6 @@ export const StreamingProvider = ({ children }: { children: ReactNode }) => {
     isPaused,
     sceneEditActive: sceneEdit.graceActive,
     states,
-    settings,
     setEngineError,
     resetSession,
     runWarmConnection,

--- a/src/context/streaming/StreamingContext.tsx
+++ b/src/context/streaming/StreamingContext.tsx
@@ -154,7 +154,7 @@ export const StreamingProvider = ({ children }: { children: ReactNode }) => {
     })
   }, [getSeedsDirPath])
 
-  const { selectSeed, lastAppliedSession, resetSession } = useSessionInit({
+  const { selectSeed, lastApplied, resetSession } = useSessionInit({
     portalState: state,
     loadingState: states.LOADING,
     isConnected: wsIsConnected(connectionStatus),
@@ -214,7 +214,7 @@ export const StreamingProvider = ({ children }: { children: ReactNode }) => {
     portalState: state,
     connectionStatus,
     settings,
-    lastAppliedSession,
+    lastApplied,
     engineError,
     hasReceivedFrame,
     // Init is considered complete once applyInitResponse has set the

--- a/src/context/streaming/streamingLifecycleEffects.ts
+++ b/src/context/streaming/streamingLifecycleEffects.ts
@@ -1,4 +1,3 @@
-import { DEFAULT_WORLD_ENGINE_MODEL } from '../../types/settings'
 import { TranslatableError } from '../../i18n'
 import type { StreamingLifecycleEffects } from './streamingLifecycleMachine'
 import type { PortalState } from '../portal/portalStateMachine'
@@ -28,9 +27,8 @@ type PortalStatesLike = {
 
 type CreateHandlersArgs = {
   log: { info: (...args: unknown[]) => void; error: (...args: unknown[]) => void }
-  settings: { engine_model?: string | null } | null
   setEngineError: (value: TranslatableError | null) => void
-  /** Clears `warmBootstrapSent` + `lastAppliedModel`; used when the
+  /** Clears `warmBootstrapSent` + `lastAppliedSession`; used when the
    *  reducer needs the next LOADING entry to start from a clean
    *  bootstrap. */
   resetSession: () => void
@@ -58,7 +56,6 @@ type LifecycleEffectHandlers = {
 
 export const createStreamingLifecycleEffectHandlers = ({
   log,
-  settings,
   setEngineError,
   resetSession,
   runWarmConnection,
@@ -94,8 +91,7 @@ export const createStreamingLifecycleEffectHandlers = ({
     clearEngineErrorOnLoadingEntry: () => setEngineError(null),
     runLoadingConnection: () => runWarmConnection(),
     startIntentionalReconnect: () => {
-      const selectedModel = settings?.engine_model || DEFAULT_WORLD_ENGINE_MODEL
-      log.info('Model changed in settings while streaming - reconnecting to start a fresh session:', selectedModel)
+      log.info('Engine settings changed while streaming - reconnecting to start a fresh session')
       resetSession()
       setConnectionLost(false)
       setSettingsOpen(false)

--- a/src/context/streaming/streamingLifecycleMachine.ts
+++ b/src/context/streaming/streamingLifecycleMachine.ts
@@ -133,7 +133,14 @@ export const streamingLifecycleReducer = (
   if (enteredLoading) {
     next.loadingConnectionRequestSeq = state.loadingConnectionRequestSeq + 1
     next.loadingAttempted = false
+    // Clear any prior connection-lost overlay: by entering LOADING we're
+    // either healing from a real disconnect (user clicked reconnect) or
+    // intentionally tearing down (process respawn from useEngineRespawn,
+    // which lives outside this reducer and so can't go through the
+    // intentional-reconnect suppression path).
+    next.connectionLostSignaled = false
     next.effects.clearEngineErrorOnLoadingEntry = true
+    next.effects.clearConnectionLost = true
     next.effects.runLoadingConnection = true
   }
 

--- a/src/context/streaming/streamingLifecycleMachine.ts
+++ b/src/context/streaming/streamingLifecycleMachine.ts
@@ -75,8 +75,12 @@ export const initialStreamingLifecycleState: StreamingLifecycleState = {
 export type StreamingLifecycleSyncPayload = {
   portalState: PortalState
   connectionStatus: ConnectionStatus
-  selectedModel: string
-  lastAppliedModel: string | null
+  /** Opaque signature of all session-class settings; built by
+   *  `getSessionSignature` in `types/settings.ts`. The reducer doesn't
+   *  care what's in it — only whether it differs from
+   *  `lastAppliedSession`. */
+  currentSessionSig: string
+  lastAppliedSession: string | null
   engineError: TranslatableError | null
   hasReceivedFrame: boolean
   initCompleted: boolean
@@ -100,8 +104,8 @@ export const streamingLifecycleReducer = (
   const {
     portalState,
     connectionStatus,
-    selectedModel,
-    lastAppliedModel,
+    currentSessionSig,
+    lastAppliedSession,
     engineError,
     hasReceivedFrame,
     initCompleted,
@@ -123,7 +127,7 @@ export const streamingLifecycleReducer = (
   const socketOpen = connectionStatus.kind === 'loading' || connectionStatus.kind === 'ready'
   const socketReady = connectionStatus.kind === 'ready'
 
-  const shouldIntentionalReconnect = inStreamingState && socketOpen && selectedModel !== lastAppliedModel
+  const shouldIntentionalReconnect = inStreamingState && socketOpen && currentSessionSig !== lastAppliedSession
 
   const enteredLoading = inLoadingState && state.lastPortalState !== PORTAL_STATES.LOADING
   if (enteredLoading) {

--- a/src/context/streaming/streamingLifecycleMachine.ts
+++ b/src/context/streaming/streamingLifecycleMachine.ts
@@ -1,6 +1,7 @@
 import { PORTAL_STATES, type PortalState } from '../portal/portalStateMachine'
 import type { ConnectionStatus } from '../../hooks/engine/useWebSocket'
 import type { TranslatableError, TranslationKey } from '../../i18n'
+import type { RestartSignatures } from '../../utils/settingsClassifier'
 
 const isActiveConnection = (s: ConnectionStatus): boolean =>
   s.kind === 'connecting' || s.kind === 'loading' || s.kind === 'ready'
@@ -9,6 +10,16 @@ const isFailedConnection = (s: ConnectionStatus): boolean => s.kind === 'idle' |
 export const STREAMING_LIFECYCLE_EVENT = {
   SYNC: 'sync'
 } as const
+
+/** Kinds of intentional restart the reducer tracks. `'reconnect'` is
+ *  the in-place version (session-class diff): the reducer emits
+ *  `startIntentionalReconnect` and orchestrates the disconnect →
+ *  LOADING transition. `'respawn'` is the heavier version
+ *  (process-class diff): `useEngineRespawn` lives outside the reducer
+ *  and owns the side effects (it has to, because `stopServer` is
+ *  async); the reducer only mirrors the intent so the
+ *  connection-lost overlay is suppressed during the disconnect. */
+export type IntentionalRestart = 'reconnect' | 'respawn'
 
 export type StreamingLifecycleEffects = {
   loadingFailureError: { transportError: TranslatableError } | { key: TranslationKey } | null
@@ -49,7 +60,11 @@ export type StreamingLifecycleState = {
   wasConnectedInStreamingState: boolean
   connectionLostSignaled: boolean
   hadEngineError: boolean
-  intentionalReconnectInProgress: boolean
+  /** Which kind of intentional restart is in flight, if any.
+   *  Drives the connection-lost / warm-error suppression and (for
+   *  `'reconnect'`) the disconnect → LOADING orchestration. Cleared
+   *  on LOADING entry and on MAIN_MENU. */
+  intentionalRestart: IntentionalRestart | null
   loadingTransitionRequestedForIntentionalReconnect: boolean
   streamingTransitionRequested: boolean
   loadingConnectionRequestSeq: number
@@ -63,7 +78,7 @@ export const initialStreamingLifecycleState: StreamingLifecycleState = {
   wasConnectedInStreamingState: false,
   connectionLostSignaled: false,
   hadEngineError: false,
-  intentionalReconnectInProgress: false,
+  intentionalRestart: null,
   loadingTransitionRequestedForIntentionalReconnect: false,
   streamingTransitionRequested: false,
   loadingConnectionRequestSeq: 0,
@@ -75,12 +90,15 @@ export const initialStreamingLifecycleState: StreamingLifecycleState = {
 export type StreamingLifecycleSyncPayload = {
   portalState: PortalState
   connectionStatus: ConnectionStatus
-  /** Opaque signature of all session-class settings; built by
-   *  `getSessionSignature` in `types/settings.ts`. The reducer doesn't
-   *  care what's in it — only whether it differs from
-   *  `lastAppliedSession`. */
-  currentSessionSig: string
-  lastAppliedSession: string | null
+  /** Current signatures of all restart-class settings. The reducer
+   *  doesn't care what's in them — only whether they differ from
+   *  `lastAppliedSignatures`. Built by `getRestartSignatures` in
+   *  `utils/settingsClassifier`. */
+  currentSignatures: RestartSignatures
+  /** Snapshot taken in `useSessionInit` at the last successful
+   *  bootstrap. `null` until the first session has been initialised
+   *  (or after a `resetSession`). */
+  lastAppliedSignatures: RestartSignatures | null
   engineError: TranslatableError | null
   hasReceivedFrame: boolean
   initCompleted: boolean
@@ -95,6 +113,25 @@ export type StreamingLifecycleEvent = {
   payload: StreamingLifecycleSyncPayload
 }
 
+/** Compute the strongest intentional-restart class implied by a
+ *  signature diff. `'respawn'` outranks `'reconnect'` because a
+ *  process-class change always implies a full session reset, and the
+ *  respawn path (stopServer + new env vars) subsumes the in-place
+ *  reconnect. Returns `null` when no diff is detected or when we're
+ *  not in a streaming-with-open-socket state where a restart makes
+ *  sense. */
+const computeIntentionalRestart = (
+  current: RestartSignatures,
+  lastApplied: RestartSignatures | null,
+  inStreamingState: boolean,
+  socketOpen: boolean
+): IntentionalRestart | null => {
+  if (!inStreamingState || !socketOpen || !lastApplied) return null
+  if (current.process !== lastApplied.process) return 'respawn'
+  if (current.session !== lastApplied.session) return 'reconnect'
+  return null
+}
+
 export const streamingLifecycleReducer = (
   state: StreamingLifecycleState,
   event: StreamingLifecycleEvent
@@ -104,8 +141,8 @@ export const streamingLifecycleReducer = (
   const {
     portalState,
     connectionStatus,
-    currentSessionSig,
-    lastAppliedSession,
+    currentSignatures,
+    lastAppliedSignatures,
     engineError,
     hasReceivedFrame,
     initCompleted,
@@ -127,7 +164,7 @@ export const streamingLifecycleReducer = (
   const socketOpen = connectionStatus.kind === 'loading' || connectionStatus.kind === 'ready'
   const socketReady = connectionStatus.kind === 'ready'
 
-  const shouldIntentionalReconnect = inStreamingState && socketOpen && currentSessionSig !== lastAppliedSession
+  const intentNeeded = computeIntentionalRestart(currentSignatures, lastAppliedSignatures, inStreamingState, socketOpen)
 
   const enteredLoading = inLoadingState && state.lastPortalState !== PORTAL_STATES.LOADING
   if (enteredLoading) {
@@ -137,25 +174,28 @@ export const streamingLifecycleReducer = (
     // either healing from a real disconnect (user clicked reconnect) or
     // intentionally tearing down (process respawn from useEngineRespawn,
     // which lives outside this reducer and so can't go through the
-    // intentional-reconnect suppression path).
+    // intentional-restart suppression path).
     next.connectionLostSignaled = false
     next.effects.clearEngineErrorOnLoadingEntry = true
     next.effects.clearConnectionLost = true
     next.effects.runLoadingConnection = true
   }
 
-  if (shouldIntentionalReconnect && !next.intentionalReconnectInProgress) {
-    next.intentionalReconnectInProgress = true
-    next.loadingTransitionRequestedForIntentionalReconnect = false
-    next.effects.startIntentionalReconnect = true
+  if (intentNeeded && state.intentionalRestart !== intentNeeded) {
+    next.intentionalRestart = intentNeeded
+    if (intentNeeded === 'reconnect') {
+      next.loadingTransitionRequestedForIntentionalReconnect = false
+      next.effects.startIntentionalReconnect = true
+    }
+    // 'respawn' has no effect — useEngineRespawn owns the side effects.
   }
 
-  if (!next.intentionalReconnectInProgress) {
+  if (next.intentionalRestart !== 'reconnect') {
     next.loadingTransitionRequestedForIntentionalReconnect = false
   }
 
   if (
-    next.intentionalReconnectInProgress &&
+    next.intentionalRestart === 'reconnect' &&
     inStreamingState &&
     connectionStatus.kind === 'idle' &&
     !next.loadingTransitionRequestedForIntentionalReconnect
@@ -198,7 +238,7 @@ export const streamingLifecycleReducer = (
   }
 
   if (inLoadingState && next.loadingAttempted && isFailedConnection(connectionStatus)) {
-    if (next.intentionalReconnectInProgress) {
+    if (next.intentionalRestart !== null) {
       next.effects.suppressedIntentionalWarmError = true
     } else {
       const transportError = connectionStatus.kind === 'error' ? connectionStatus.error : null
@@ -216,7 +256,7 @@ export const streamingLifecycleReducer = (
 
   if (next.wasConnectedInStreamingState && inStreamingState && isFailedConnection(connectionStatus)) {
     if (!next.connectionLostSignaled) {
-      if (next.intentionalReconnectInProgress) {
+      if (next.intentionalRestart !== null) {
         next.effects.suppressedIntentionalConnectionLost = true
       } else {
         next.effects.connectionLost = true
@@ -233,13 +273,13 @@ export const streamingLifecycleReducer = (
     next.loadingAttempted = false
     next.wasConnectedInStreamingState = false
     next.connectionLostSignaled = false
-    next.intentionalReconnectInProgress = false
+    next.intentionalRestart = null
     next.loadingTransitionRequestedForIntentionalReconnect = false
     next.effects.clearConnectionLost = true
   }
 
-  if (inLoadingState && socketOpen && next.intentionalReconnectInProgress) {
-    next.intentionalReconnectInProgress = false
+  if (inLoadingState && socketOpen && next.intentionalRestart !== null) {
+    next.intentionalRestart = null
     next.loadingTransitionRequestedForIntentionalReconnect = false
   }
 

--- a/src/context/streaming/streamingLifecyclePayload.ts
+++ b/src/context/streaming/streamingLifecyclePayload.ts
@@ -1,4 +1,5 @@
-import { DEFAULT_WORLD_ENGINE_MODEL } from '../../types/settings'
+import type { Settings } from '../../types/settings'
+import { getSessionSignature } from '../../utils/settingsClassifier'
 import type { ConnectionStatus } from '../../hooks/engine/useWebSocket'
 import type { TranslatableError } from '../../i18n'
 import type { PortalState } from '../portal/portalStateMachine'
@@ -7,8 +8,8 @@ import type { StreamingLifecycleSyncPayload } from './streamingLifecycleMachine'
 type BuildStreamingLifecycleSyncPayloadArgs = {
   portalState: PortalState
   connectionStatus: ConnectionStatus
-  engineModel?: string | null
-  lastAppliedModel: string | null
+  settings: Settings
+  lastAppliedSession: string | null
   engineError: TranslatableError | null
   hasReceivedFrame: boolean
   initCompleted: boolean
@@ -16,25 +17,16 @@ type BuildStreamingLifecycleSyncPayloadArgs = {
   settingsOpen: boolean
   isPaused: boolean
   sceneEditActive: boolean
-  sceneAuthoringEnabled?: boolean
-  engineQuant?: string
 }
 
 export const buildStreamingLifecycleSyncPayload = (
   args: BuildStreamingLifecycleSyncPayloadArgs
 ): StreamingLifecycleSyncPayload => {
-  // Encode scene_authoring_enabled and quant into the model key so toggling
-  // either triggers the same intentional-reconnect flow as switching models.
-  const baseModel = args.engineModel || DEFAULT_WORLD_ENGINE_MODEL
-  const quant = args.engineQuant ?? 'none'
-  let selectedModel = args.sceneAuthoringEnabled ? `${baseModel}+scene_authoring` : baseModel
-  selectedModel = `${selectedModel}+${quant}`
-
   return {
     portalState: args.portalState,
     connectionStatus: args.connectionStatus,
-    selectedModel,
-    lastAppliedModel: args.lastAppliedModel,
+    currentSessionSig: getSessionSignature(args.settings),
+    lastAppliedSession: args.lastAppliedSession,
     engineError: args.engineError,
     hasReceivedFrame: args.hasReceivedFrame,
     initCompleted: args.initCompleted,

--- a/src/context/streaming/streamingLifecyclePayload.ts
+++ b/src/context/streaming/streamingLifecyclePayload.ts
@@ -1,15 +1,15 @@
 import type { Settings } from '../../types/settings'
-import { getSessionSignature } from '../../utils/settingsClassifier'
 import type { ConnectionStatus } from '../../hooks/engine/useWebSocket'
 import type { TranslatableError } from '../../i18n'
 import type { PortalState } from '../portal/portalStateMachine'
 import type { StreamingLifecycleSyncPayload } from './streamingLifecycleMachine'
+import { getRestartSignatures, type RestartSignatures } from '../../utils/settingsClassifier'
 
 type BuildStreamingLifecycleSyncPayloadArgs = {
   portalState: PortalState
   connectionStatus: ConnectionStatus
   settings: Settings
-  lastAppliedSession: string | null
+  lastApplied: RestartSignatures | null
   engineError: TranslatableError | null
   hasReceivedFrame: boolean
   initCompleted: boolean
@@ -25,8 +25,8 @@ export const buildStreamingLifecycleSyncPayload = (
   return {
     portalState: args.portalState,
     connectionStatus: args.connectionStatus,
-    currentSessionSig: getSessionSignature(args.settings),
-    lastAppliedSession: args.lastAppliedSession,
+    currentSignatures: getRestartSignatures(args.settings),
+    lastAppliedSignatures: args.lastApplied,
     engineError: args.engineError,
     hasReceivedFrame: args.hasReceivedFrame,
     initCompleted: args.initCompleted,

--- a/src/hooks/streaming/useEngineRespawn.ts
+++ b/src/hooks/streaming/useEngineRespawn.ts
@@ -1,24 +1,25 @@
 import { useEffect, useRef } from 'react'
-import { ENGINE_MODES, type EngineMode } from '../../types/settings'
+import { ENGINE_MODES, type Settings } from '../../types/settings'
+import { classifySettingsDiff } from '../../utils/settingsClassifier'
 import type { PortalState } from '../../context/portal/portalStateMachine'
 import type { TranslatableError } from '../../i18n'
 import { createLogger } from '../../utils/logger'
 
 const log = createLogger('Streaming/Respawn')
 
-/** Watches the two settings that take effect at server-process spawn
- *  time — `engine_mode` (local-vs-remote process) and `offline_mode`
- *  (env vars injected when uv spawns the Python server) — and forces a
- *  full teardown-and-reconnect when either flips mid-stream. The env
- *  is only honoured when the process starts, so a hot toggle would
- *  otherwise leave the server running with stale environment.
+/** Watches for `process`-class settings changes — fields whose effects
+ *  only take hold when the server process is (re)spawned: `engine_mode`
+ *  (local-vs-remote process), `offline_mode` (env vars injected at uv
+ *  spawn time), and `server_url` (target host). `SETTING_CLASSES` in
+ *  `types/settings.ts` is the single source of truth for which fields
+ *  belong here.
  *
- *  Offline-mode changes only matter in standalone mode; in remote-server
- *  mode the env vars don't apply (we connect to a server we didn't
- *  spawn). The first render establishes the baseline without firing. */
+ *  When any of them flips mid-stream we tear down: close the WS, stop
+ *  the local server (no-op in remote-server mode — there's no process
+ *  we own), clear the engine error, and bounce back through LOADING.
+ *  The first render establishes the baseline without firing. */
 export function useEngineRespawn(opts: {
-  engineMode: EngineMode
-  offlineMode: boolean
+  settings: Settings
   portalState: PortalState
   mainMenuState: PortalState
   loadingState: PortalState
@@ -29,8 +30,7 @@ export function useEngineRespawn(opts: {
   transitionTo: (state: PortalState) => void
 }): void {
   const {
-    engineMode,
-    offlineMode,
+    settings,
     portalState,
     mainMenuState,
     loadingState,
@@ -41,22 +41,29 @@ export function useEngineRespawn(opts: {
     transitionTo
   } = opts
 
-  const prevEngineModeRef = useRef(engineMode)
-  const prevOfflineModeRef = useRef(offlineMode)
+  const prevSettingsRef = useRef<Settings | null>(null)
 
   useEffect(() => {
-    const prevMode = prevEngineModeRef.current
-    const prevOffline = prevOfflineModeRef.current
-    prevEngineModeRef.current = engineMode
-    prevOfflineModeRef.current = offlineMode
+    const prev = prevSettingsRef.current
+    prevSettingsRef.current = settings
+    if (!prev) return // baseline on first render
 
-    const engineModeChanged = !!prevMode && prevMode !== engineMode
-    const offlineChanged = prevOffline !== offlineMode && engineMode === ENGINE_MODES.STANDALONE
-
-    if (!engineModeChanged && !offlineChanged) return
+    if (classifySettingsDiff(prev, settings) !== 'process') return
     if (portalState === mainMenuState) return
 
-    log.info(`Respawn: engine_mode ${prevMode}->${engineMode}, offline ${prevOffline}->${offlineMode}`)
+    // `offline_mode` only takes effect when we own the server process; in
+    // remote-server mode the env vars don't apply, so a hot toggle there is
+    // a no-op aside from any unrelated process-class field that flipped.
+    if (
+      prev.engine_mode === settings.engine_mode &&
+      prev.server_url === settings.server_url &&
+      prev.offline_mode !== settings.offline_mode &&
+      settings.engine_mode !== ENGINE_MODES.STANDALONE
+    ) {
+      return
+    }
+
+    log.info('Process-class settings changed - respawning server')
 
     disconnect()
     if (isServerRunning) {
@@ -65,8 +72,7 @@ export function useEngineRespawn(opts: {
     setEngineError(null)
     transitionTo(loadingState)
   }, [
-    engineMode,
-    offlineMode,
+    settings,
     portalState,
     mainMenuState,
     loadingState,

--- a/src/hooks/streaming/useEngineRespawn.ts
+++ b/src/hooks/streaming/useEngineRespawn.ts
@@ -65,12 +65,24 @@ export function useEngineRespawn(opts: {
 
     log.info('Process-class settings changed - respawning server')
 
-    disconnect()
-    if (isServerRunning) {
-      stopServer().catch((err) => log.error('Failed to stop server during respawn:', err))
-    }
-    setEngineError(null)
-    transitionTo(loadingState)
+    // Tear down in order, awaiting `stopServer` so the IPC "server
+    // exited" event has propagated to `isServerRunning=false` before
+    // LOADING fires. Without the await, the warm-connect flow reads
+    // stale React state, picks the attach-to-running branch, and
+    // throws "Server exited before becoming ready" while the doomed
+    // server finishes dying.
+    void (async () => {
+      disconnect()
+      if (isServerRunning) {
+        try {
+          await stopServer()
+        } catch (err) {
+          log.error('Failed to stop server during respawn:', err)
+        }
+      }
+      setEngineError(null)
+      transitionTo(loadingState)
+    })()
   }, [
     settings,
     portalState,

--- a/src/hooks/streaming/useSessionInit.ts
+++ b/src/hooks/streaming/useSessionInit.ts
@@ -4,6 +4,7 @@ import { buildSessionConfig } from '../../context/streaming/sessionConfig'
 import type { PortalState } from '../../context/portal/portalStateMachine'
 import type { InitRequest, InitResponseData } from '../../types/protocol.generated'
 import { DEFAULT_WORLD_ENGINE_MODEL, type Settings } from '../../types/settings'
+import { getLiveSignature, getSessionSignature } from '../../utils/settingsClassifier'
 import { createLogger } from '../../utils/logger'
 
 const log = createLogger('Streaming/Session')
@@ -18,16 +19,17 @@ type SendInit = (params: Omit<InitRequest, 'type' | 'req_id'>) => Promise<InitRe
  *  - `lastSeedRef`: the most-recently-loaded seed (filename + base64)
  *    so we can resume with the same seed across reconnects without
  *    re-loading the IPC blob.
- *  - `lastAppliedModelRef`: the model+quant+scene-authoring key the
- *    server is currently configured for. Surfaced via
- *    `lastAppliedModel` so the lifecycle machine can detect a settings
- *    change that requires an intentional reconnect.
+ *  - `lastAppliedSession`: the session signature
+ *    (`getSessionSignature(settings)`) the server is currently
+ *    configured for. Surfaced so the lifecycle reducer can detect a
+ *    settings change that requires an intentional reconnect.
  *  - `warmBootstrapSentRef`: an idempotency guard so the bootstrap
  *    effect runs once per LOADING → connected transition.
  *
- *  `resetSession()` clears the bootstrap guard and the applied model;
- *  the lifecycle effects fire it on intentional reconnect and on
- *  teardown so the next LOADING entry starts from a clean slate. */
+ *  `resetSession()` clears the bootstrap guard and the applied session
+ *  signature; the lifecycle effects fire it on intentional reconnect
+ *  and on teardown so the next LOADING entry starts from a clean
+ *  slate. */
 export function useSessionInit(opts: {
   portalState: PortalState
   loadingState: PortalState
@@ -40,7 +42,7 @@ export function useSessionInit(opts: {
   setPlaceholderFrame: (frame: Blob | string | null) => void
 }): {
   selectSeed: (filename: string) => Promise<void>
-  lastAppliedModel: string | null
+  lastAppliedSession: string | null
   resetSession: () => void
 } {
   const {
@@ -57,7 +59,7 @@ export function useSessionInit(opts: {
 
   const lastSeedRef = useRef<{ filename: string; imageData: string } | null>(null)
   const warmBootstrapSentRef = useRef(false)
-  const [lastAppliedModel, setLastAppliedModel] = useState<string | null>(null)
+  const [lastAppliedSession, setLastAppliedSession] = useState<string | null>(null)
 
   // Read-latest settings without depending on the whole settings object —
   // the live re-apply effect is keyed on a small subset and reads the
@@ -96,12 +98,9 @@ export function useSessionInit(opts: {
         setPlaceholderFrame(new Blob([bytes], { type: 'image/jpeg' }))
       }
 
-      // Set lastAppliedModel before await so the lifecycle machine doesn't
-      // see a model mismatch during the re-render triggered by applyInitResponse.
-      const quant = settings.engine_quant ?? 'none'
-      setLastAppliedModel(
-        settings.scene_authoring_enabled ? `${selectedModel}+scene_authoring+${quant}` : `${selectedModel}+${quant}`
-      )
+      // Set lastAppliedSession before await so the lifecycle machine doesn't
+      // see a session mismatch during the re-render triggered by applyInitResponse.
+      setLastAppliedSession(getSessionSignature(settings))
 
       // App version — embedded into recording metadata so MP4s carry a
       // self-describing record of what Biome build produced them. Best-effort;
@@ -142,13 +141,13 @@ export function useSessionInit(opts: {
   }, [isConnected, setPlaceholderFrame])
 
   // Live re-apply of the session config during streaming. Any change to
-  // a live-toggleable SessionConfig field (action logging, video
-  // recording, inference cap) re-sends the full config; the server diffs
+  // a `live`-class setting (action_logging, video recording fields,
+  // cap_inference_fps, …) re-sends the full config; the server diffs
   // against current state and applies whatever differs without tearing
-  // the session down. Model / quant / scene-authoring changes can't be
-  // hot-swapped — those trigger a full lifecycle reconnect instead, so
-  // they're deliberately not in this dep list to avoid racing the
-  // reconnect with a stale-state init send.
+  // the session down. `SETTING_CLASSES` in `types/settings.ts` is the
+  // single source of truth for which fields belong here — adding one to
+  // the `live` bucket auto-wires it through `liveSignature`.
+  const liveSignature = getLiveSignature(settings)
   useEffect(() => {
     if (!isStreaming || !isConnected) return
     const run = async () => {
@@ -160,16 +159,7 @@ export function useSessionInit(opts: {
       })
     }
     run().catch((err) => log.error('Failed to re-apply session config:', err))
-  }, [
-    isStreaming,
-    isConnected,
-    isStandaloneMode,
-    settings.debug_overlays?.action_logging,
-    settings.recording?.enabled,
-    settings.recording?.output_dir,
-    settings.cap_inference_fps,
-    sendInit
-  ])
+  }, [isStreaming, isConnected, isStandaloneMode, liveSignature, sendInit])
 
   const selectSeed = useCallback(
     async (filename: string) => {
@@ -190,8 +180,8 @@ export function useSessionInit(opts: {
 
   const resetSession = useCallback(() => {
     warmBootstrapSentRef.current = false
-    setLastAppliedModel(null)
+    setLastAppliedSession(null)
   }, [])
 
-  return { selectSeed, lastAppliedModel, resetSession }
+  return { selectSeed, lastAppliedSession, resetSession }
 }

--- a/src/hooks/streaming/useSessionInit.ts
+++ b/src/hooks/streaming/useSessionInit.ts
@@ -4,7 +4,7 @@ import { buildSessionConfig } from '../../context/streaming/sessionConfig'
 import type { PortalState } from '../../context/portal/portalStateMachine'
 import type { InitRequest, InitResponseData } from '../../types/protocol.generated'
 import { DEFAULT_WORLD_ENGINE_MODEL, type Settings } from '../../types/settings'
-import { getLiveSignature, getSessionSignature } from '../../utils/settingsClassifier'
+import { getLiveSignature, getRestartSignatures, type RestartSignatures } from '../../utils/settingsClassifier'
 import { createLogger } from '../../utils/logger'
 
 const log = createLogger('Streaming/Session')
@@ -19,15 +19,15 @@ type SendInit = (params: Omit<InitRequest, 'type' | 'req_id'>) => Promise<InitRe
  *  - `lastSeedRef`: the most-recently-loaded seed (filename + base64)
  *    so we can resume with the same seed across reconnects without
  *    re-loading the IPC blob.
- *  - `lastAppliedSession`: the session signature
- *    (`getSessionSignature(settings)`) the server is currently
- *    configured for. Surfaced so the lifecycle reducer can detect a
- *    settings change that requires an intentional reconnect.
+ *  - `lastApplied`: the session+process signatures the server is
+ *    currently configured for. Surfaced so the lifecycle reducer can
+ *    detect a settings change that requires either an intentional
+ *    reconnect (session diff) or a respawn (process diff).
  *  - `warmBootstrapSentRef`: an idempotency guard so the bootstrap
  *    effect runs once per LOADING → connected transition.
  *
- *  `resetSession()` clears the bootstrap guard and the applied session
- *  signature; the lifecycle effects fire it on intentional reconnect
+ *  `resetSession()` clears the bootstrap guard and the applied
+ *  signatures; the lifecycle effects fire it on intentional reconnect
  *  and on teardown so the next LOADING entry starts from a clean
  *  slate. */
 export function useSessionInit(opts: {
@@ -42,7 +42,7 @@ export function useSessionInit(opts: {
   setPlaceholderFrame: (frame: Blob | string | null) => void
 }): {
   selectSeed: (filename: string) => Promise<void>
-  lastAppliedSession: string | null
+  lastApplied: RestartSignatures | null
   resetSession: () => void
 } {
   const {
@@ -59,7 +59,7 @@ export function useSessionInit(opts: {
 
   const lastSeedRef = useRef<{ filename: string; imageData: string } | null>(null)
   const warmBootstrapSentRef = useRef(false)
-  const [lastAppliedSession, setLastAppliedSession] = useState<string | null>(null)
+  const [lastApplied, setLastApplied] = useState<RestartSignatures | null>(null)
 
   // Read-latest settings without depending on the whole settings object —
   // the live re-apply effect is keyed on a small subset and reads the
@@ -98,9 +98,10 @@ export function useSessionInit(opts: {
         setPlaceholderFrame(new Blob([bytes], { type: 'image/jpeg' }))
       }
 
-      // Set lastAppliedSession before await so the lifecycle machine doesn't
-      // see a session mismatch during the re-render triggered by applyInitResponse.
-      setLastAppliedSession(getSessionSignature(settings))
+      // Set lastApplied before await so the lifecycle machine doesn't
+      // see a stale mismatch during the re-render triggered by
+      // applyInitResponse.
+      setLastApplied(getRestartSignatures(settings))
 
       // App version — embedded into recording metadata so MP4s carry a
       // self-describing record of what Biome build produced them. Best-effort;
@@ -180,8 +181,8 @@ export function useSessionInit(opts: {
 
   const resetSession = useCallback(() => {
     warmBootstrapSentRef.current = false
-    setLastAppliedSession(null)
+    setLastApplied(null)
   }, [])
 
-  return { selectSeed, lastAppliedSession, resetSession }
+  return { selectSeed, lastApplied, resetSession }
 }

--- a/src/hooks/streaming/useStreamingLifecycle.ts
+++ b/src/hooks/streaming/useStreamingLifecycle.ts
@@ -34,10 +34,8 @@ export function useStreamingLifecycle(opts: {
   // Payload inputs
   portalState: PortalState
   connectionStatus: ConnectionStatus
-  engineModel: string | null | undefined
-  engineQuant: string | undefined
-  sceneAuthoringEnabled: boolean | undefined
-  lastAppliedModel: string | null
+  settings: Settings
+  lastAppliedSession: string | null
   engineError: TranslatableError | null
   hasReceivedFrame: boolean
   initCompleted: boolean
@@ -48,7 +46,6 @@ export function useStreamingLifecycle(opts: {
 
   // Handler inputs
   states: PortalStates
-  settings: Settings
   setEngineError: (err: TranslatableError | null) => void
   resetSession: () => void
   runWarmConnection: () => void
@@ -72,25 +69,21 @@ export function useStreamingLifecycle(opts: {
       payload: buildStreamingLifecycleSyncPayload({
         portalState: opts.portalState,
         connectionStatus: opts.connectionStatus,
-        engineModel: opts.engineModel,
-        lastAppliedModel: opts.lastAppliedModel,
+        settings: opts.settings,
+        lastAppliedSession: opts.lastAppliedSession,
         engineError: opts.engineError,
         hasReceivedFrame: opts.hasReceivedFrame,
         initCompleted: opts.initCompleted,
         isPointerLocked: opts.isPointerLocked,
         settingsOpen: opts.settingsOpen,
         isPaused: opts.isPaused,
-        sceneEditActive: opts.sceneEditActive,
-        sceneAuthoringEnabled: opts.sceneAuthoringEnabled,
-        engineQuant: opts.engineQuant
+        sceneEditActive: opts.sceneEditActive
       })
     })
   }, [
     opts.portalState,
     opts.connectionStatus,
-    opts.engineModel,
-    opts.engineQuant,
-    opts.sceneAuthoringEnabled,
+    opts.settings,
     opts.engineError,
     opts.hasReceivedFrame,
     opts.initCompleted,
@@ -98,14 +91,13 @@ export function useStreamingLifecycle(opts: {
     opts.settingsOpen,
     opts.isPaused,
     opts.sceneEditActive,
-    opts.lastAppliedModel
+    opts.lastAppliedSession
   ])
 
   // Run the effects emitted by the latest reducer pass.
   useEffect(() => {
     const handlers = createStreamingLifecycleEffectHandlers({
       log,
-      settings: opts.settings,
       setEngineError: opts.setEngineError,
       resetSession: opts.resetSession,
       runWarmConnection: opts.runWarmConnection,

--- a/src/hooks/streaming/useStreamingLifecycle.ts
+++ b/src/hooks/streaming/useStreamingLifecycle.ts
@@ -13,6 +13,7 @@ import type { ConnectionStatus } from '../engine/useWebSocket'
 import type { PortalState } from '../../context/portal/portalStateMachine'
 import type { TranslatableError } from '../../i18n'
 import type { Settings } from '../../types/settings'
+import type { RestartSignatures } from '../../utils/settingsClassifier'
 import { createLogger } from '../../utils/logger'
 
 const log = createLogger('Streaming/Lifecycle')
@@ -35,7 +36,7 @@ export function useStreamingLifecycle(opts: {
   portalState: PortalState
   connectionStatus: ConnectionStatus
   settings: Settings
-  lastAppliedSession: string | null
+  lastApplied: RestartSignatures | null
   engineError: TranslatableError | null
   hasReceivedFrame: boolean
   initCompleted: boolean
@@ -70,7 +71,7 @@ export function useStreamingLifecycle(opts: {
         portalState: opts.portalState,
         connectionStatus: opts.connectionStatus,
         settings: opts.settings,
-        lastAppliedSession: opts.lastAppliedSession,
+        lastApplied: opts.lastApplied,
         engineError: opts.engineError,
         hasReceivedFrame: opts.hasReceivedFrame,
         initCompleted: opts.initCompleted,
@@ -91,7 +92,7 @@ export function useStreamingLifecycle(opts: {
     opts.settingsOpen,
     opts.isPaused,
     opts.sceneEditActive,
-    opts.lastAppliedSession
+    opts.lastApplied
   ])
 
   // Run the effects emitted by the latest reducer pass.

--- a/src/types/settings.ts
+++ b/src/types/settings.ts
@@ -1,5 +1,6 @@
 import { z } from 'zod'
 import { SUPPORTED_LOCALES } from '../i18n/locales'
+import type { AllPaths } from '../utils/settingsClassifier'
 
 export const ENGINE_MODES = { STANDALONE: 'standalone', SERVER: 'server' } as const
 export const LOCALE_OPTIONS = ['system', ...SUPPORTED_LOCALES] as const
@@ -61,6 +62,10 @@ export const DEFAULT_AUDIO = {
   music_volume: 0.3
 } as const
 
+// Adding a field? Classify it in `SETTING_CLASSES` below if the server
+// cares — anything unlisted silently defaults to `'none'` (no restart on
+// change), which is the wrong default for any field that touches the
+// engine.
 export const settingsSchema = z.object({
   locale: z.enum(LOCALE_OPTIONS).default('system'),
   server_url: z.string().default(''),
@@ -130,3 +135,35 @@ export const settingsSchema = z.object({
 export type Settings = z.infer<typeof settingsSchema>
 export type EngineMode = Settings['engine_mode']
 export type Keybindings = Settings['keybindings']
+
+/** How a change to a `Settings` field affects the running session.
+ *
+ *  - `none`: no server impact.
+ *  - `live`: re-sent in a mid-stream `InitRequest`; server diffs and
+ *    applies in place. No modal.
+ *  - `session`: disconnect + warm reconnect + new InitRequest. Modal.
+ *  - `process`: server respawn (standalone) or retarget (server mode). Modal. */
+export type SettingClass = 'none' | 'live' | 'session' | 'process'
+
+/** Interior + leaf paths into `Settings` (`recording`, `recording.enabled`). */
+export type SettingPath = AllPaths<Settings>
+
+/** Restart class per setting. Top-level keys cover the whole subtree;
+ *  dot-paths split when siblings differ. Unlisted paths are `'none'`. */
+export const SETTING_CLASSES: Partial<Record<SettingPath, SettingClass>> = {
+  // Process: env vars / URL only apply at process spawn time.
+  engine_mode: 'process',
+  offline_mode: 'process',
+  server_url: 'process',
+
+  // Session: model / engine / world identity.
+  engine_model: 'session',
+  engine_backend: 'session',
+  engine_quant: 'session',
+  scene_authoring_enabled: 'session',
+
+  // Live: server reconfigures in place.
+  cap_inference_fps: 'live',
+  recording: 'live',
+  'debug_overlays.action_logging': 'live'
+}

--- a/src/utils/settingsClassifier.ts
+++ b/src/utils/settingsClassifier.ts
@@ -1,0 +1,57 @@
+import { SETTING_CLASSES, type SettingClass, type SettingPath, type Settings } from '../types/settings'
+
+/** Recursively derive every valid path into an object — both interior
+ *  nodes (`recording`) and leaves (`recording.enabled`). The keyspace
+ *  of `SETTING_CLASSES` (in `types/settings.ts`) is `AllPaths<Settings>`
+ *  so a typo'd path fails tsc. */
+export type AllPaths<T> =
+  T extends ReadonlyArray<unknown>
+    ? never
+    : T extends object
+      ? {
+          [K in keyof T & string]: T[K] extends ReadonlyArray<unknown>
+            ? K
+            : T[K] extends object
+              ? K | `${K}.${AllPaths<T[K]>}`
+              : K
+        }[keyof T & string]
+      : never
+
+const PATHS_OF_CLASS = (cls: SettingClass): SettingPath[] =>
+  (Object.entries(SETTING_CLASSES) as [SettingPath, SettingClass][]).filter(([, c]) => c === cls).map(([p]) => p)
+
+const SESSION_PATHS = PATHS_OF_CLASS('session')
+const PROCESS_PATHS = PATHS_OF_CLASS('process')
+const LIVE_PATHS = PATHS_OF_CLASS('live')
+
+const getValueAtPath = (settings: Settings, path: string): unknown =>
+  path
+    .split('.')
+    .reduce<unknown>(
+      (acc, key) => (acc && typeof acc === 'object' ? (acc as Record<string, unknown>)[key] : undefined),
+      settings
+    )
+
+const signatureFor = (settings: Settings, paths: SettingPath[]): string =>
+  paths.map((p) => JSON.stringify(getValueAtPath(settings, p) ?? null)).join('|')
+
+export const getSessionSignature = (s: Settings): string => signatureFor(s, SESSION_PATHS)
+export const getProcessSignature = (s: Settings): string => signatureFor(s, PROCESS_PATHS)
+export const getLiveSignature = (s: Settings): string => signatureFor(s, LIVE_PATHS)
+
+/** The strongest class of change between `prev` and `next`. `process`
+ *  beats `session` beats `live` beats `none` — apply the heaviest
+ *  applicable handler. */
+export const classifySettingsDiff = (prev: Settings, next: Settings): SettingClass => {
+  if (getProcessSignature(prev) !== getProcessSignature(next)) return 'process'
+  if (getSessionSignature(prev) !== getSessionSignature(next)) return 'session'
+  if (getLiveSignature(prev) !== getLiveSignature(next)) return 'live'
+  return 'none'
+}
+
+/** True when the diff requires a modal confirmation (session or
+ *  process class). `live` and `none` apply silently. */
+export const diffRequiresRestartConfirmation = (prev: Settings, next: Settings): boolean => {
+  const cls = classifySettingsDiff(prev, next)
+  return cls === 'session' || cls === 'process'
+}

--- a/src/utils/settingsClassifier.ts
+++ b/src/utils/settingsClassifier.ts
@@ -39,6 +39,17 @@ export const getSessionSignature = (s: Settings): string => signatureFor(s, SESS
 export const getProcessSignature = (s: Settings): string => signatureFor(s, PROCESS_PATHS)
 export const getLiveSignature = (s: Settings): string => signatureFor(s, LIVE_PATHS)
 
+/** Bundle of signatures for the two restart-triggering classes. The
+ *  lifecycle reducer compares this against the last-applied snapshot to
+ *  decide whether a settings change requires an in-place reconnect or a
+ *  full server respawn — see `intentionalRestart` in the reducer. */
+export type RestartSignatures = { session: string; process: string }
+
+export const getRestartSignatures = (s: Settings): RestartSignatures => ({
+  session: getSessionSignature(s),
+  process: getProcessSignature(s)
+})
+
 /** The strongest class of change between `prev` and `next`. `process`
  *  beats `session` beats `live` beats `none` — apply the heaviest
  *  applicable handler. */


### PR DESCRIPTION
Toggling the engine backend mid-session did not reset the server; instead, it went to the pause menu. I realised that the logic for choosing to restart or reset the server was all over the place, which meant that this bug would keep reoccurring. To fix this, I refactored the associated code to institute one source of truth. Afterwards, while testing it, I discovered that there were several bugs with offline mode.

## Single source of truth for restart classification

Every `Settings` field now has an associated class (`none` / `live` / `session` / `process`) declared once in `src/types/settings.ts`. All downstream code responsible for controlling the server now consults that map, ensuring consistency of behaviour.

The classifier supports both top-level keys (covering whole subtrees) and dot-paths (when siblings disagree, e.g. `debug_overlays.action_logging` is `live` while its UI-only siblings default to `none`).

## Lifecycle bugs surfaced while testing the refactor

A handful of pre-existing races and gaps showed up once mid-session restart was actually being exercised:

- **Race between server stop and warm-reconnect**: The respawn flow fired stop+transition in the same tick, so the warm flow saw a stale "server still running" snapshot, attached to the doomed server, and threw "Server exited before becoming ready". Now waits for stop to land before transitioning.
- **Offline-mode server spawn bombed on dependency resolve**: In offline mode uv couldn't reach the index to verify the lockfile and bailed out, even though the venv was already correct. The server spawn now skips the resolve+sync passes when offline.
- **Connection-lost overlay stuck around through respawn**: It was only cleared on main-menu entry, so a process-class respawn left it visible all the way back into streaming. Now also cleared on LOADING entry, and suppressed entirely during intentional restarts.

## Diagnostic clarity

The `check-engine-status` dependency-validation step now surfaces uv's actual stderr/stdout when it fails, instead of silently returning false. Saves a round of guessing the next time a venv ends up out of sync.