### PR TITLE
feat(shutdown): graceful server shutdown + harden parent watchdog

### DIFF
--- a/electron/ipc/server.ts
+++ b/electron/ipc/server.ts
@@ -7,13 +7,7 @@ import path from 'node:path'
 import { getEngineDir, getHfHomeDir, getHfHubCacheDir } from '../lib/paths.js'
 import { getUvBinaryPath, getUvEnvVars, getBundledPythonIncludeDir } from '../lib/uv.js'
 import { getHiddenWindowOptions } from '../lib/platform.js'
-import {
-  getServerState,
-  setServerProcess,
-  setServerReady,
-  clearServerState,
-  stopServerSync
-} from '../lib/serverState.js'
+import { getServerState, setServerProcess, setServerReady, clearServerState, stopServer } from '../lib/serverState.js'
 import { copyServerComponentFiles } from '../lib/serverFiles.js'
 import { parseLogLine } from '../lib/logRecord.js'
 import { getLogger } from '../lib/logger.js'
@@ -114,9 +108,19 @@ export function registerServerIpc(): void {
       '--launched-from-standalone'
     ]
 
-    // python on win32 seems to have issues with --parent-pid correctly detecting parent pid and kills itself
-    const serverArgs =
-      process.platform === 'win32' ? baseServerArgs : [...baseServerArgs, '--parent-pid', String(process.pid)]
+    // Parent-process watchdog: the Python server force-exits if this Electron
+    // process disappears. On Windows we also pass our process-creation time
+    // so the watchdog can defeat PID recycling — without it, a freshly spawned
+    // OS process inheriting our PID would look "alive" to the server even
+    // though Biome itself is long gone.
+    const parentStartTimeSec = Date.now() / 1000 - process.uptime()
+    const serverArgs = [
+      ...baseServerArgs,
+      '--parent-pid',
+      String(process.pid),
+      '--parent-start-time',
+      parentStartTimeSec.toFixed(3)
+    ]
 
     // Spawn the server
     const child = spawn(uvBinary, serverArgs, {
@@ -186,8 +190,8 @@ export function registerServerIpc(): void {
     return `Server started on port ${port} (PID: ${pid})`
   })
 
-  ipcMain.handle('stop-engine-server', () => {
-    const result = stopServerSync()
+  ipcMain.handle('stop-engine-server', async () => {
+    const result = await stopServer()
     if (!result) {
       return 'Server already stopped'
     }

--- a/electron/lib/serverState.ts
+++ b/electron/lib/serverState.ts
@@ -36,7 +36,7 @@ export function clearServerState(): void {
   state.ready = false
 }
 
-/** Synchronously stop the running server process tree */
+/** Synchronously stop the running server process tree (force-kill path). */
 export function stopServerSync(): string | null {
   if (!state.process) {
     return null
@@ -71,4 +71,67 @@ export function stopServerSync(): string | null {
   clearServerState()
   log.info('Server stopped successfully')
   return pid ? `Server stopped (PID: ${pid})` : 'Server stopped'
+}
+
+/**
+ * Stop the running server. First asks the server to shut itself down via
+ * `POST /shutdown` so the FastAPI lifespan teardown runs (releasing GPU
+ * memory, finalising recordings). Falls back to `stopServerSync` if the
+ * HTTP request fails or the process hasn't exited within `gracePeriodMs`.
+ *
+ * Use this for any user-initiated or app-quit shutdown. Reserve
+ * `stopServerSync` for emergency paths (uncaughtException, hard crash)
+ * where there's no time to be polite.
+ */
+export async function stopServer({ gracePeriodMs = 10000 }: { gracePeriodMs?: number } = {}): Promise<string | null> {
+  const proc = state.process
+  const port = state.port
+  if (!proc) {
+    return null
+  }
+  const pid = proc.pid
+
+  // If the process is already dead but `clearServerState` hasn't been
+  // invoked yet (e.g. exit handler not yet fired), short-circuit.
+  if (proc.exitCode !== null) {
+    clearServerState()
+    return pid ? `Server already exited (PID: ${pid})` : 'Server already exited'
+  }
+
+  // Set up the exit-detection promise before issuing the request so we
+  // can't miss the event if the server exits before we start awaiting.
+  const exitedNaturally = new Promise<boolean>((resolve) => {
+    const onExit = () => resolve(true)
+    proc.once('exit', onExit)
+    setTimeout(() => {
+      proc.removeListener('exit', onExit)
+      resolve(false)
+    }, gracePeriodMs).unref()
+  })
+
+  if (port !== null) {
+    log.info('Requesting graceful shutdown', { fields: { pid: pid ?? -1, port } })
+    try {
+      await fetch(`http://127.0.0.1:${port}/shutdown`, {
+        method: 'POST',
+        signal: AbortSignal.timeout(500)
+      })
+    } catch (e) {
+      // Server may already be dying or unreachable — fall through to the
+      // process-exit wait, which will time out quickly and force-kill.
+      log.warning('Shutdown request failed, will wait for exit then force-kill', {
+        exception: e instanceof Error ? e.message : String(e)
+      })
+    }
+  }
+
+  const exited = await exitedNaturally
+  if (exited) {
+    log.info('Server exited gracefully', { fields: { pid: pid ?? -1 } })
+    clearServerState()
+    return pid ? `Server stopped gracefully (PID: ${pid})` : 'Server stopped gracefully'
+  }
+
+  log.warning('Graceful shutdown timed out, forcing kill', { fields: { pid: pid ?? -1, gracePeriodMs } })
+  return stopServerSync()
 }

--- a/electron/main.ts
+++ b/electron/main.ts
@@ -2,7 +2,7 @@ import { app, BrowserWindow, net, protocol, shell } from 'electron'
 import path from 'node:path'
 import fs from 'node:fs'
 import { registerAllIpc } from './ipc/index.js'
-import { stopServerSync } from './lib/serverState.js'
+import { getServerState, stopServer, stopServerSync } from './lib/serverState.js'
 import { getBackgroundsDir } from './ipc/backgrounds.js'
 import { getCurrentRecordingsDir } from './ipc/recordings.js'
 import { getLogger } from './lib/logger.js'
@@ -185,23 +185,49 @@ app.on('activate', () => {
   }
 })
 
-app.on('before-quit', () => {
-  log.info('App quitting, stopping server')
-  stopServerSync()
+// `before-quit` re-fires after we call `app.quit()` (and may re-fire if the
+// user triggers quit again while shutdown is in flight). `complete` lets the
+// final pass through unchanged so Electron actually tears the window down;
+// `inFlight` swallows any extra mid-shutdown events without re-launching a
+// second `stopServer`.
+let serverShutdownComplete = false
+let serverShutdownInFlight = false
+
+app.on('before-quit', (event) => {
+  if (serverShutdownComplete) return
+  if (!getServerState().process) return
+  if (serverShutdownInFlight) {
+    event.preventDefault()
+    return
+  }
+
+  event.preventDefault()
+  serverShutdownInFlight = true
+  log.info('App quitting, stopping server gracefully')
+
+  void stopServer().finally(() => {
+    serverShutdownComplete = true
+    app.quit()
+  })
 })
+
+// On a CTRL+C / SIGTERM the OS gives us limited time before it force-kills us,
+// so use a tight grace budget — the server's lifespan teardown is best-effort.
+const signalGracePeriodMs = 1500
 
 process.on('SIGINT', () => {
   log.info('Received SIGINT, stopping server')
-  stopServerSync()
-  process.exit(0)
+  void stopServer({ gracePeriodMs: signalGracePeriodMs }).finally(() => process.exit(0))
 })
 
 process.on('SIGTERM', () => {
   log.info('Received SIGTERM, stopping server')
-  stopServerSync()
-  process.exit(0)
+  void stopServer({ gracePeriodMs: signalGracePeriodMs }).finally(() => process.exit(0))
 })
 
+// uncaughtException leaves the event loop in an undefined state — async I/O
+// (including the graceful HTTP request) can't be trusted to make progress.
+// Sync force-kill is the only safe path here.
 process.on('uncaughtException', (err) => {
   log.error('Uncaught exception, stopping server', {
     exception: err instanceof Error ? (err.stack ?? err.message) : String(err)

--- a/server-components/main.py
+++ b/server-components/main.py
@@ -17,6 +17,7 @@ import sys
 from contextlib import asynccontextmanager
 from dataclasses import dataclass
 
+import psutil
 import structlog
 
 import util.server_logging  # noqa: F401  # pyright: ignore[reportUnusedImport]  -- side-effect: install TeeStream + crash hooks before any logging happens
@@ -39,6 +40,10 @@ class StartupConfig:
     before the lifespan body itself runs."""
 
     parent_pid: int | None = None
+    # Epoch seconds for the parent's process-creation time, as reported by
+    # the launcher. Paired with `parent_pid` to defend against PID recycling
+    # on Windows: a recycled PID matches, but the creation time won't.
+    parent_start_time: float | None = None
     # True when the launching Biome instance is in standalone mode and
     # owns this process's lifecycle — set via `--launched-from-standalone`
     # so the renderer can refuse to point itself at a server it would
@@ -47,10 +52,22 @@ class StartupConfig:
     launched_from_standalone: bool = False
 
 
-# If launched with --parent-pid, poll the parent PID and exit if it dies.
+# If launched with --parent-pid, poll the parent and exit if it dies.
 # Linux's prctl(PR_SET_PDEATHSIG) is the kernel-level fallback we'd ideally
 # use, but Python doesn't expose it portably; the polling watchdog covers
-# both Linux and Windows.
+# both Linux and Windows. On Windows the bare `os.kill(pid, 0)` check is
+# unreliable in the face of PID recycling — kernel reuses PIDs aggressively
+# and the new occupant can be running as a different user — so when the
+# launcher passes `--parent-start-time` we additionally compare the parent's
+# process-creation time via psutil.
+
+
+# Tolerance for clock skew between the launcher's clock and the kernel's
+# recorded process-creation timestamp. Process-creation times sit at
+# millisecond precision; one second is generous enough to absorb the
+# stringification round-trip and any small drift, while still being well
+# below the gap any recycled PID would exhibit.
+_PARENT_START_TIME_TOLERANCE_SEC = 1.0
 
 
 class ParentWatchdog:
@@ -58,26 +75,42 @@ class ParentWatchdog:
     parent dies. Constructed in `__main__` (one-shot startup check),
     then run as an asyncio task by the lifespan (continuous polling)."""
 
-    def __init__(self, parent_pid: int) -> None:
+    def __init__(self, parent_pid: int, parent_start_time: float | None = None) -> None:
         self.parent_pid = parent_pid
+        self.parent_start_time = parent_start_time
+
+    def _parent_alive(self) -> bool:
+        """True iff a process with the parent's PID exists and (when
+        `parent_start_time` is known) has a matching creation timestamp."""
+        try:
+            proc = psutil.Process(self.parent_pid)
+        except psutil.NoSuchProcess:
+            return False
+        if self.parent_start_time is None:
+            return True
+        try:
+            create_time = proc.create_time()
+        except psutil.NoSuchProcess:
+            return False
+        except psutil.AccessDenied:
+            # Process exists but we can't read its metadata. Treat as alive
+            # rather than self-exit on a transient permission glitch.
+            return True
+        return abs(create_time - self.parent_start_time) <= _PARENT_START_TIME_TOLERANCE_SEC
 
     def check_alive_or_exit(self) -> None:
         """Synchronous one-shot check at startup, in case the parent
         is already gone by the time we get here."""
-        try:
-            os.kill(self.parent_pid, 0)
-        except OSError:
-            logger.error("Parent process is already gone, shutting down", parent_pid=self.parent_pid)  # noqa: TRY400  -- OSError is a "parent gone" signal, not a real exception; traceback is noise
+        if not self._parent_alive():
+            logger.error("Parent process is already gone, shutting down", parent_pid=self.parent_pid)
             os._exit(1)
 
     async def run(self) -> None:
         """Continuous polling. Run as an asyncio task from the lifespan."""
         while True:
             await asyncio.sleep(2)
-            try:
-                os.kill(self.parent_pid, 0)  # signal 0 = existence check
-            except OSError:
-                logger.error("Parent process is gone, shutting down", parent_pid=self.parent_pid)  # noqa: TRY400  -- OSError is a "parent gone" signal, not a real exception; traceback is noise
+            if not self._parent_alive():
+                logger.error("Parent process is gone, shutting down", parent_pid=self.parent_pid)
                 os._exit(1)
 
 
@@ -166,7 +199,7 @@ async def lifespan(app: FastAPI):
     cfg: StartupConfig = app.state.startup_config
     watchdog_task = None
     if cfg.parent_pid is not None:
-        watchdog_task = asyncio.create_task(ParentWatchdog(cfg.parent_pid).run())
+        watchdog_task = asyncio.create_task(ParentWatchdog(cfg.parent_pid, cfg.parent_start_time).run())
 
     yield
 
@@ -197,6 +230,15 @@ if __name__ == "__main__":
         "--parent-pid", type=int, default=None, help="PID of parent process; server exits if parent dies"
     )
     parser.add_argument(
+        "--parent-start-time",
+        type=float,
+        default=None,
+        help=(
+            "Epoch-seconds creation timestamp of the parent process. When paired with --parent-pid, used to guard"
+            " against PID recycling: a recycled PID won't match the original parent's creation time."
+        ),
+    )
+    parser.add_argument(
         "--launched-from-standalone",
         action="store_true",
         help=(
@@ -208,21 +250,30 @@ if __name__ == "__main__":
 
     app.state.startup_config = StartupConfig(
         parent_pid=args.parent_pid,
+        parent_start_time=args.parent_start_time,
         launched_from_standalone=args.launched_from_standalone,
     )
     if args.parent_pid is not None:
-        logger.info("Monitoring parent process", parent_pid=args.parent_pid)
-        ParentWatchdog(args.parent_pid).check_alive_or_exit()
+        logger.info("Monitoring parent process", parent_pid=args.parent_pid, parent_start_time=args.parent_start_time)
+        ParentWatchdog(args.parent_pid, args.parent_start_time).check_alive_or_exit()
+
+    # Construct the uvicorn Server explicitly (rather than via `uvicorn.run`)
+    # so the `/shutdown` route can flip `should_exit` on the live instance,
+    # giving the lifespan teardown a chance to run before the launcher
+    # falls back to SIGKILL.
+    config = uvicorn.Config(
+        app,
+        host=args.host,
+        port=args.port,
+        ws_ping_interval=300,
+        ws_ping_timeout=300,
+        log_config=None,
+    )
+    server = uvicorn.Server(config)
+    app.state.uvicorn_server = server
 
     try:
-        uvicorn.run(
-            app,
-            host=args.host,
-            port=args.port,
-            ws_ping_interval=300,
-            ws_ping_timeout=300,
-            log_config=None,
-        )
+        server.run()
     except BaseException:
         logger.exception("Fatal exception at server entrypoint")
         raise

--- a/server-components/server/routes.py
+++ b/server-components/server/routes.py
@@ -33,7 +33,7 @@ import contextlib
 import os
 import shutil
 from pathlib import Path
-from typing import Annotated, Literal, cast
+from typing import TYPE_CHECKING, Annotated, Literal, cast
 
 import structlog
 import yaml
@@ -68,6 +68,9 @@ from server.session.workers import run_session
 from server.startup import ServerStartup
 from util.server_logging import stream_logs_to_client
 from util.system_info import SystemMonitor
+
+if TYPE_CHECKING:
+    import uvicorn
 
 logger = structlog.stdlib.get_logger(__name__)
 router = APIRouter()
@@ -289,6 +292,40 @@ async def health(request: Request, startup: Annotated[ServerStartup, Depends(get
         capabilities=supported_capabilities(),
         launched_from_standalone=launched_from_standalone,
     )
+
+
+class ShutdownResponse(BaseModel):
+    status: Literal["shutting_down", "already_shutting_down"]
+
+
+class ShutdownUnavailableError(RuntimeError):
+    def __init__(self) -> None:
+        super().__init__("uvicorn_server is not attached to app.state; cannot signal graceful shutdown")
+
+
+@router.post("/shutdown")
+async def shutdown(request: Request) -> ShutdownResponse:
+    """Signal the uvicorn server to exit on its next tick. The route returns
+    before the loop actually unwinds so the launcher gets an HTTP 200; the
+    lifespan teardown then runs as uvicorn drains. Localhost-only because
+    that's how the server is bound — any local process can also `kill -9`
+    us, so this isn't a new attack surface.
+
+    No-op (idempotent `already_shutting_down`) if the flag is already set,
+    so a launcher that retries doesn't see a confusing error."""
+    server_obj = getattr(request.app.state, "uvicorn_server", None)
+    if server_obj is None:
+        # Lifespan-loaded apps under `uvicorn.run(app)` don't expose the
+        # Server object; main.py wires one up explicitly precisely so this
+        # endpoint works. If we ever lose that wiring, fail loudly rather
+        # than silently no-op'ing the launcher's only graceful path.
+        raise ShutdownUnavailableError
+    server = cast("uvicorn.Server", server_obj)
+    if server.should_exit:
+        return ShutdownResponse(status="already_shutting_down")
+    logger.info("Shutdown requested via /shutdown endpoint")
+    server.should_exit = True
+    return ShutdownResponse(status="shutting_down")
 
 
 def _read_model_type(path: str) -> str | None:


### PR DESCRIPTION
Fixes #84.

- Graceful pre-kill: a new POST /shutdown route flips uvicorn's should_exit so the FastAPI lifespan teardown runs (releasing GPU memory) before the launcher has to SIGKILL. Electron's stopServer() hits /shutdown, waits up to 10s for the process to exit, and only then falls back to the old SIGKILL/treeKill path. Used by before-quit, SIGINT/SIGTERM, and the stop-engine-server IPC. uncaughtException still goes straight to sync force-kill.

- ParentWatchdog now compares the parent's process creation time via psutil, not just PID existence. Defeats PID recycling on Windows.