### PR TITLE
fix: handle WebSocket close race in run_sender

### DIFF
--- a/server-components/server/session/workers.py
+++ b/server-components/server/session/workers.py
@@ -282,7 +282,7 @@ async def run_sender(conn: Connection) -> None:
                         await conn.websocket.send_bytes(payload)
                     else:
                         await conn.send_message(payload)
-                except Exception:
+                except Exception:  # noqa: BLE001
                     conn.running = False
                     return
         except Exception:

--- a/server-components/server/session/workers.py
+++ b/server-components/server/session/workers.py
@@ -275,10 +275,16 @@ async def run_sender(conn: Connection) -> None:
             conn.frame_ready.clear()
             while not conn.frame_queue.empty():
                 payload = conn.frame_queue.get_nowait()
-                if isinstance(payload, bytes):
-                    await conn.websocket.send_bytes(payload)
-                else:
-                    await conn.send_message(payload)
+                if not conn.running:
+                    break
+                try:
+                    if isinstance(payload, bytes):
+                        await conn.websocket.send_bytes(payload)
+                    else:
+                        await conn.send_message(payload)
+                except Exception:
+                    conn.running = False
+                    return
         except Exception:
             logger.exception("Sender error")
             conn.running = False


### PR DESCRIPTION
Fixes a reproducible disconnect bug when running Biome with a remote server.

The issue is a race condition in run_sender — when the client disconnects, the WebSocket closes but the generator thread keeps queuing frames, so send_bytes gets called on an already-closed socket and throws:

RuntimeError: Unexpected ASGI message 'websocket.send', after sending 'websocket.close' or response already completed.

Two small changes to the while loop in run_sender:
1. Added if not conn.running: break before each send so we stop draining the queue immediately on disconnect
2. Wrapped send_bytes/send_message in their own try/except so if the send fails in the gap between the check and the actual send, it exits cleanly rather than crashing

